### PR TITLE
Document security invoker view option for auth.users exposed

### DIFF
--- a/splinter.sql
+++ b/splinter.sql
@@ -87,10 +87,11 @@ from
         on c.oid = r.ev_class
     join pg_namespace n
         on n.oid = c.relnamespace
+    join pg_class pg_class_auth_users
+        on d.refobjid = pg_class_auth_users.oid
 where
     d.refobjid = 'auth.users'::regclass
     and d.deptype = 'n'
-    and c.relkind in ('v', 'm') -- v for view, m for materialized view
     and n.nspname = 'public'
     and (
       pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
@@ -98,6 +99,43 @@ where
     )
     -- Exclude self
     and c.relname <> '0002_auth_users_exposed'
+    -- There are 3 insecure configurations
+    and
+    (
+        -- Materialized views don't support RLS so this is insecure by default
+        (c.relkind in ('m')) -- m for materialized view
+        or
+        -- Standard View, accessible to anon or authenticated that is security_definer
+        (
+            c.relkind = 'v' -- v for view
+            -- Exclude security invoker views 
+            and not (
+                lower(coalesce(c.reloptions::text,'{}'))::text[]
+                && array[
+                    'security_invoker=1',
+                    'security_invoker=true',
+                    'security_invoker=yes',
+                    'security_invoker=on'
+                ]
+            )
+        )
+        or
+        -- Standard View, security invoker, but no RLS enabled on auth.users
+        (
+            c.relkind in ('v') -- v for view
+            -- is security invoker 
+            and (
+                lower(coalesce(c.reloptions::text,'{}'))::text[]
+                && array[
+                    'security_invoker=1',
+                    'security_invoker=true',
+                    'security_invoker=yes',
+                    'security_invoker=on'
+                ]
+            )
+            and not pg_class_auth_users.relrowsecurity 
+        )
+    )
 group by
     c.relname, c.oid)
 union all

--- a/test/expected/0002_auth_users_exposed.out
+++ b/test/expected/0002_auth_users_exposed.out
@@ -5,13 +5,43 @@ begin;
 ------+-------+--------+-------------+--------+-------------+----------+-----------
 (0 rows)
 
-    -- Create a view that exposes auth.users
-    create view public.oops as
-    select * from auth.users;
+    savepoint a;
+    -- Failure mode 1: A materialized view
+    -- Materialized views can not support row level security so they are always an overexposure risk
+    create materialized view public.foo as select * from auth.users;
+    -- 1 entry
     select * from lint."0002_auth_users_exposed";
-        name        | level |  facing  |                                                                            description                                                                             |                                                      detail                                                       |                         remediation                         |                                   metadata                                   |           cache_key            
---------------------+-------+----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+------------------------------------------------------------------------------+--------------------------------
- auth_users_exposed | WARN  | EXTERNAL | Detects if auth.users is exposed to anon or authenticated roles via a view or materialized view in the public schema, potentially compromising user data security. | View/Materialized View "oops" in the public schema may expose \`auth.users\` data to anon or authenticated roles. | https://supabase.github.io/splinter/0002_auth_users_exposed | {"name": "oops", "type": "view", "schema": "public", "exposed_to": ["anon"]} | auth_users_exposed_public_oops
+        name        | level |  facing  |                                                                            description                                                                             |                                                      detail                                                      |                         remediation                         |                                  metadata                                   |           cache_key           
+--------------------+-------+----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------------------+-------------------------------
+ auth_users_exposed | WARN  | EXTERNAL | Detects if auth.users is exposed to anon or authenticated roles via a view or materialized view in the public schema, potentially compromising user data security. | View/Materialized View "foo" in the public schema may expose \`auth.users\` data to anon or authenticated roles. | https://supabase.github.io/splinter/0002_auth_users_exposed | {"name": "foo", "type": "view", "schema": "public", "exposed_to": ["anon"]} | auth_users_exposed_public_foo
 (1 row)
+
+    rollback to savepoint a;
+    -- Failure mode 2: View that is security definer
+    create view public.bar as select * from auth.users;
+    -- 1 entry
+    select * from lint."0002_auth_users_exposed";
+        name        | level |  facing  |                                                                            description                                                                             |                                                      detail                                                      |                         remediation                         |                                  metadata                                   |           cache_key           
+--------------------+-------+----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------------------+-------------------------------
+ auth_users_exposed | WARN  | EXTERNAL | Detects if auth.users is exposed to anon or authenticated roles via a view or materialized view in the public schema, potentially compromising user data security. | View/Materialized View "bar" in the public schema may expose \`auth.users\` data to anon or authenticated roles. | https://supabase.github.io/splinter/0002_auth_users_exposed | {"name": "bar", "type": "view", "schema": "public", "exposed_to": ["anon"]} | auth_users_exposed_public_bar
+(1 row)
+
+    rollback to savepoint a;
+    -- Failure mode 3: View that is security invoker, but RLS not enabled on auth.user
+    create view public.baz with (security_invoker=on) as select * from auth.users;
+    -- 1 entry
+    select * from lint."0002_auth_users_exposed";
+        name        | level |  facing  |                                                                            description                                                                             |                                                      detail                                                      |                         remediation                         |                                  metadata                                   |           cache_key           
+--------------------+-------+----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+-----------------------------------------------------------------------------+-------------------------------
+ auth_users_exposed | WARN  | EXTERNAL | Detects if auth.users is exposed to anon or authenticated roles via a view or materialized view in the public schema, potentially compromising user data security. | View/Materialized View "baz" in the public schema may expose \`auth.users\` data to anon or authenticated roles. | https://supabase.github.io/splinter/0002_auth_users_exposed | {"name": "baz", "type": "view", "schema": "public", "exposed_to": ["anon"]} | auth_users_exposed_public_baz
+(1 row)
+
+    -- resolve the issue by enabling RLS on auth.users
+    alter table auth.users enable row level security;
+    -- 0 entries
+    select * from lint."0002_auth_users_exposed";
+ name | level | facing | description | detail | remediation | metadata | cache_key 
+------+-------+--------+-------------+--------+-------------+----------+-----------
+(0 rows)
 
 rollback;

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -5,7 +5,7 @@ set search_path = '';
 create schema lint;
 
 create schema auth;
-create view auth.users as select 1;
+create table auth.users (id uuid primary key);
 create function auth.uid() returns uuid language sql as $$select gen_random_uuid()$$;
 create function auth.jwt() returns jsonb language sql as $$select jsonb_build_object()$$;
 create function auth.role() returns text language sql as $$select ''$$;

--- a/test/sql/0002_auth_users_exposed.sql
+++ b/test/sql/0002_auth_users_exposed.sql
@@ -3,10 +3,35 @@ begin;
     -- No issues
     select * from lint."0002_auth_users_exposed";
 
-    -- Create a view that exposes auth.users
-    create view public.oops as
-    select * from auth.users;
+    savepoint a;
 
+    -- Failure mode 1: A materialized view
+    -- Materialized views can not support row level security so they are always an overexposure risk
+    create materialized view public.foo as select * from auth.users;
+    -- 1 entry
     select * from lint."0002_auth_users_exposed";
+
+
+    rollback to savepoint a;
+
+
+    -- Failure mode 2: View that is security definer
+    create view public.bar as select * from auth.users;
+    -- 1 entry
+    select * from lint."0002_auth_users_exposed";
+
+
+    rollback to savepoint a;
+
+
+    -- Failure mode 3: View that is security invoker, but RLS not enabled on auth.user
+    create view public.baz with (security_invoker=on) as select * from auth.users;
+    -- 1 entry
+    select * from lint."0002_auth_users_exposed";
+    -- resolve the issue by enabling RLS on auth.users
+    alter table auth.users enable row level security;
+    -- 0 entries
+    select * from lint."0002_auth_users_exposed";
+
 
 rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates the "`auth.users` exposed" lint to check for 3 different conditions

- auth.users exposed in a materialized view (no RLS possible)
- auth.users exposed in a SECURITY DEFINER view (no RLS possible)
- auth.users exposed in SECURITY INVOKER view, but RLS not enabled on auth.users

We also add tests for each of these cases, and confirm that resolving the issue in the third case removes the record.

Finally, the docs have been updated to reflect document security_invoker + RLS as an option for resolving the problem in addition to the trigger based solution already in the docs

resolves #23 