### PR TITLE
add lint for rls disabled in public

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -49,7 +49,7 @@ else
 fi
 
 # Execute the test fixtures
-psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -d contrib_regression
+psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -d contrib_regression
 
 # Run tests
 ${REGRESS} --use-existing --dbname=contrib_regression --inputdir=${TESTDIR} ${TESTS}

--- a/docs/0013_rls_disabled_in_public.md
+++ b/docs/0013_rls_disabled_in_public.md
@@ -1,0 +1,38 @@
+
+Level: ERROR
+
+### Rationale
+
+Tables in the `public` schema are accessible over Supabase APIs. If row level security (RLS) is not enabled on a `public` table, anyone with the project's URL can CREATE/READ/UPDATE/DELETE (CRUD) rows in the impacted table. Publicly exposing full CRUD to the internet is a critically unsafe configuration.
+
+
+### How to Resolve
+
+To enable RLS on a table execute:
+
+```sql
+alter table <schema>.<table> enable row level security;
+```
+
+Note that after enabling RLS you will not be able to read or write data to the table via Supabase APIs until you create [row level security policies](https://supabase.com/docs/guides/auth/row-level-security) to control access.
+
+### Example
+
+Given the schema:
+
+```sql
+create table public.blog(
+    id int primary key,
+    user_id uuid not null,
+    title text not null
+);
+```
+
+Any user with access to the project's URL will be able to perform CRUD operations on the `public.blog` table. To restrict access to users specified in row level security policies, enable RLS with:
+
+
+```sql
+alter table public.blog enable row level security;
+```
+
+

--- a/docs/0013_rls_disabled_in_public.md
+++ b/docs/0013_rls_disabled_in_public.md
@@ -14,7 +14,7 @@ To enable RLS on a table execute:
 alter table <schema>.<table> enable row level security;
 ```
 
-Note that after enabling RLS you will not be able to read or write data to the table via Supabase APIs until you create [row level security policies](https://supabase.com/docs/guides/auth/row-level-security) to control access.
+Note that after enabling RLS you will not be able to use the `anon` role to read or write data to the table via Supabase APIs until you create [row level security policies](https://supabase.com/docs/guides/auth/row-level-security) to control access.
 
 ### Example
 

--- a/lints/0013_rls_disabled_in_public.sql
+++ b/lints/0013_rls_disabled_in_public.sql
@@ -1,0 +1,32 @@
+create view lint."0013_rls_disabled_in_public" as
+
+select
+    'rls_disabled_in_public' as name,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    'Detects cases where row level security (RLS) has not been enabled on a table in the `public` schema.' as description,
+    format(
+        'Table \`%s.%s\` is in the `public` but RLS has not been enabled.',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.github.io/splinter/0013_rls_disabled_in_public' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'rls_disabled_in_public_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+where
+    c.relkind = 'r' -- regular tables
+    and n.nspname = 'public'
+    -- RLS is disabled
+    and not c.relrowsecurity;

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -19,6 +19,7 @@ nav:
       - Duplicate Index: '0009_duplicate_index.md'
       - Security Definer View: '0010_security_definer_view.md'
       - Function Search Path Mutable: '0011_function_search_path_mutable.md'
+      - RLS Disabled in Public: '0013_rls_disabled_in_public.md'
 
 theme:
     name: 'material'

--- a/splinter.sql
+++ b/splinter.sql
@@ -583,3 +583,35 @@ where
     )
     -- Search path not set to ''
     and not coalesce(p.proconfig, '{}') && array['search_path=""'])
+union all
+(
+select
+    'rls_disabled_in_public' as name,
+    'ERROR' as level,
+    'EXTERNAL' as facing,
+    'Detects cases where row level security (RLS) has not been enabled on a table in the `public` schema.' as description,
+    format(
+        'Table \`%s.%s\` is in the `public` but RLS has not been enabled.',
+        n.nspname,
+        c.relname
+    ) as detail,
+    'https://supabase.github.io/splinter/0013_rls_disabled_in_public' as remediation,
+    jsonb_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'rls_disabled_in_public_%s_%s',
+        n.nspname,
+        c.relname
+    ) as cache_key
+from
+    pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n
+        on c.relnamespace = n.oid
+where
+    c.relkind = 'r' -- regular tables
+    and n.nspname = 'public'
+    -- RLS is disabled
+    and not c.relrowsecurity)

--- a/test/expected/0013_rls_disabled_in_public.out
+++ b/test/expected/0013_rls_disabled_in_public.out
@@ -1,0 +1,35 @@
+begin;
+  -- 0 issues
+  select * from lint."0013_rls_disabled_in_public";
+ name | level | facing | description | detail | remediation | metadata | cache_key 
+------+-------+--------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  create table public.foo( it int primary key );
+  -- 1 issue
+  select * from lint."0013_rls_disabled_in_public";
+          name          | level |  facing  |                                             description                                              |                                detail                                 |                           remediation                           |                       metadata                       |             cache_key             
+------------------------+-------+----------+------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------+-----------------------------------------------------------------+------------------------------------------------------+-----------------------------------
+ rls_disabled_in_public | ERROR | EXTERNAL | Detects cases where row level security (RLS) has not been enabled on a table in the `public` schema. | Table \`public.foo\` is in the `public` but RLS has not been enabled. | https://supabase.github.io/splinter/0013_rls_disabled_in_public | {"name": "foo", "type": "table", "schema": "public"} | rls_disabled_in_public_public_foo
+(1 row)
+
+  -- Resolve the issue by enabling RLS
+  alter table public.foo enable row level security;
+  -- 0 issue
+  select * from lint."0013_rls_disabled_in_public";
+ name | level | facing | description | detail | remediation | metadata | cache_key 
+------+-------+--------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  -- Confirm that the lint only applies to `public` tables
+  -- by creating a table in a different schema and confirming
+  -- that the lint does not fire
+  create schema xyz;
+  create table xyz.bar( it int primary key );
+  -- 0 issue
+  select * from lint."0013_rls_disabled_in_public";
+ name | level | facing | description | detail | remediation | metadata | cache_key 
+------+-------+--------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+rollback;

--- a/test/sql/0013_rls_disabled_in_public.sql
+++ b/test/sql/0013_rls_disabled_in_public.sql
@@ -1,0 +1,26 @@
+begin;
+
+  -- 0 issues
+  select * from lint."0013_rls_disabled_in_public";
+
+  create table public.foo( it int primary key );
+
+  -- 1 issue
+  select * from lint."0013_rls_disabled_in_public";
+
+  -- Resolve the issue by enabling RLS
+  alter table public.foo enable row level security;
+
+  -- 0 issue
+  select * from lint."0013_rls_disabled_in_public";
+
+  -- Confirm that the lint only applies to `public` tables
+  -- by creating a table in a different schema and confirming
+  -- that the lint does not fire
+  create schema xyz;
+  create table xyz.bar( it int primary key );
+
+  -- 0 issue
+  select * from lint."0013_rls_disabled_in_public";
+
+rollback;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds a lint to detect if RLS has not been enabled on a table in the `public` schema.

[Docs Preview](https://supabase.github.io/splinter/0013_rls_disabled_in_public/)


resolves #29 