### PR TITLE
Set `search_path` to empty before running lints

### DIFF
--- a/bin/compile.py
+++ b/bin/compile.py
@@ -40,7 +40,7 @@ directory_path = "./lints"
 sql_map = load_sql_files(directory_path)
 
 with open("splinter.sql", "w") as f:
-    f.write("\nunion all\n".join(sql_map.values()))
+    f.write("set local search_path = '';\n\n" + "\nunion all\n".join(sql_map.values()))
 
 with open("splinter.json", "w") as f:
     json.dump(sql_map, f, indent=4)

--- a/splinter.sql
+++ b/splinter.sql
@@ -1,3 +1,5 @@
+set local search_path = '';
+
 (
 with foreign_keys as (
     select


### PR DESCRIPTION
## What kind of change does this PR introduce?
Sets the `search_path` to `''` before running lints to ensure consistent reflection of SQL definitions