### PR TITLE
fix: erroneous `create view` in splinter.sql

### DIFF
--- a/lints/0020_table_bloat.sql
+++ b/lints/0020_table_bloat.sql
@@ -1,4 +1,4 @@
-create or replace view lint."0020_table_bloat" as
+create view lint."0020_table_bloat" as
 
 with constants as (
     select current_setting('block_size')::numeric as bs, 23 as hdr, 4 as ma

--- a/splinter.sql
+++ b/splinter.sql
@@ -968,8 +968,7 @@ where
     -- Constant requirements
     and 'pgmq_public' = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ','))))))
 union all
-(create or replace view lint."0020_table_bloat" as
-
+(
 with constants as (
     select current_setting('block_size')::numeric as bs, 23 as hdr, 4 as ma
 ),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There's a `create or replace view` in the table bloat lint in splinter.sql. It wasn't omitted in `compile.py` because we're using `create or replace view` instead of `create view`

## What is the new behavior?

 `create or replace view` -> `create view`