### PR TITLE
Correct combined access policy logic

### DIFF
--- a/docs/0006_multiple_permissive_policies.md
+++ b/docs/0006_multiple_permissive_policies.md
@@ -42,7 +42,7 @@ create policy grade_level_access on employee_data
     using (grade_level <= current_user_grade_level());
 ```
 
-The implementation contains a logic error. As written, every employee can see `employee_data` for every other employee within their departemnt. Similarly, every employee can see every other employee's data at or below their own grade level.
+The implementation contains a logic error. As written, every employee can see `employee_data` for every other employee within their department. Similarly, every employee can see every other employee's data at or below their own grade level.
 
 To address this issue, we can combine the two policies.
 


### PR DESCRIPTION
The documentation here describes combining access policies to avoid logic errors, but the intent described doesn't appear to match what was coded in the example.

The `or` element provides the same behaviour as the pair of separate policies, and inverting the grade_level check doesn't appear to be required based on the described intent.