### PR TITLE
fix: exclude aggregates and window functions from search path lint

### DIFF
--- a/lints/0011_function_search_path_mutable.sql
+++ b/lints/0011_function_search_path_mutable.sql
@@ -36,6 +36,7 @@ where
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude functions owned by extensions
+    and p.prokind not in ('a', 'w') -- exclude aggregates and window functions
     -- Search path not set
     and not exists (
         select 1

--- a/splinter.sql
+++ b/splinter.sql
@@ -662,6 +662,7 @@ where
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude functions owned by extensions
+    and p.prokind not in ('a', 'w') -- exclude aggregates and window functions
     -- Search path not set
     and not exists (
         select 1

--- a/test/expected/0011_function_search_path_mutable.out
+++ b/test/expected/0011_function_search_path_mutable.out
@@ -47,4 +47,23 @@ begin;
 ------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
 (0 rows)
 
+  -- Create an aggregate function (should not be flagged)
+  create function public.mysum_state(state integer, val integer)
+    returns integer
+    language sql
+    set search_path = ''
+  as $$
+    select state + val;
+  $$;
+  create aggregate public.mysum(integer) (
+    sfunc = public.mysum_state,
+    stype = integer,
+    initcond = '0'
+  );
+  -- 0 issues: aggregate is excluded, state function has search_path set
+  select * from lint."0011_function_search_path_mutable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
 rollback;

--- a/test/sql/0011_function_search_path_mutable.sql
+++ b/test/sql/0011_function_search_path_mutable.sql
@@ -38,6 +38,22 @@ begin;
   -- 1 issue
   select * from lint."0011_function_search_path_mutable";
 
+  -- Create an aggregate function (should not be flagged)
+  create function public.mysum_state(state integer, val integer)
+    returns integer
+    language sql
+    set search_path = ''
+  as $$
+    select state + val;
+  $$;
 
+  create aggregate public.mysum(integer) (
+    sfunc = public.mysum_state,
+    stype = integer,
+    initcond = '0'
+  );
+
+  -- 0 issues: aggregate is excluded, state function has search_path set
+  select * from lint."0011_function_search_path_mutable";
 
 rollback;


### PR DESCRIPTION
Fixes #139

The `function_search_path_mutable` lint queries `pg_proc` without filtering on `prokind`, so it flags aggregate and window functions. These can't have `search_path` configured -- PostgreSQL rejects it:

```
ALTER FUNCTION public.mysum(integer) SET search_path = '';
ERROR:  "public.mysum" is an aggregate function
```

This adds `p.prokind not in ('a', 'w')` to exclude aggregates and window functions from the lint.

**Changes:**
- `lints/0011_function_search_path_mutable.sql` -- filter on `prokind`
- `splinter.sql` -- same
- `test/sql/0011_function_search_path_mutable.sql` -- test case creating an aggregate, verifying it's not flagged
- `test/expected/0011_function_search_path_mutable.out` -- expected output