### PR TITLE
docs(0006): clarify multiple permissive policies example and fix logic bug

### DIFF
--- a/docs/0006_multiple_permissive_policies.md
+++ b/docs/0006_multiple_permissive_policies.md
@@ -32,9 +32,9 @@ Since any one of N permissive policies can provide a user access to a given tabl
 Consider a table `employee_data` with two permissive policies:
 
 Policy A allows access to employees in the same department.
-Policy B allows access to employees at or above a certain grade level.
+Policy B allows access to employees at or below the current user's grade level.
 
-Our intention is for users to be able to see employee data for employees within their own department who are below the querying user's grade level.
+Our intention is for users to be able to see employee data for employees within their own department who are at or below the querying user's grade level.
 
 ```sql
 -- Policy A
@@ -48,7 +48,7 @@ create policy grade_level_access on employee_data
     using (grade_level <= current_user_grade_level());
 ```
 
-The implementation contains a logic error. As written, every employee can see `employee_data` for every other employee within their departemnt. Similarly, every employee can see every other employee's data at or below their own grade level.
+The implementation contains a logic error. As written, every employee can see `employee_data` for every other employee within their department, regardless of grade level. Similarly, every employee can see every other employee's data at or below their own grade level, regardless of department. Each row that satisfies at least one policy — not both, as intended — will be returned.
 
 To address this issue, we can combine the two policies.
 
@@ -60,7 +60,7 @@ create policy consolidated_access on employee_data
     for select
     using (
         department = current_user_department()
-        or grade_level >= current_user_grade_level()
+        and grade_level <= current_user_grade_level()
     );
 ```
 


### PR DESCRIPTION
Per supabase/supabase#44600, the 'How to Resolve' section of the `0006_multiple_permissive_policies` lint has prose that doesn't match the SQL, a typo, and a 'consolidated' policy that doesn't actually fix the bug it's supposed to fix.

## Changes

1. **Policy B description** was 'at or above a certain grade level', but the SQL uses `grade_level <= current_user_grade_level()`. Match the prose to the code: 'at or below the current user's grade level.'

2. **Stated intention** was 'below the querying user's grade level' even though the example uses `<=`. Updated to 'at or below'.

3. **Typo:** 'departemnt' → 'department'.

4. **Added clarity** to the failure-mode paragraph — 'regardless of grade level' / 'regardless of department' so readers can see why the original setup is wrong, and an explicit note that the rows that come through are the ones satisfying *at least one* policy (OR semantics), not both.

5. **The 'consolidated' policy still contained the original bug** — it used `OR` and `>=`, which is the same broken semantics in different syntax. Replaced with `AND grade_level <= current_user_grade_level()` so the policy actually implements the stated intention.

Closes supabase/supabase#44600