### PR TITLE
fix: exclude PostGIS system tables from RLS check

### DIFF
--- a/lints/0013_rls_disabled_in_public.sql
+++ b/lints/0013_rls_disabled_in_public.sql
@@ -1,5 +1,4 @@
 create view lint."0013_rls_disabled_in_public" as
-
 select
     'rls_disabled_in_public' as name,
     'RLS Disabled in Public' as title,
@@ -8,7 +7,7 @@ select
     array['SECURITY'] as categories,
     'Detects cases where row level security (RLS) has not been enabled on tables in schemas exposed to PostgREST' as description,
     format(
-        'Table \`%s.%s\` is public, but RLS has not been enabled.',
+        'Table `%s.%s` is public, but RLS has not been enabled.',
         n.nspname,
         c.relname
     ) as detail,
@@ -38,4 +37,11 @@ where
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+    )
+    and c.relname not in (
+        'spatial_ref_sys',
+        'geometry_columns',
+        'geography_columns',
+        'raster_columns',
+        'raster_overviews'
     );


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The security advisor flags public.spatial_ref_sys as a critical RLS 
issue when the PostGIS extension is enabled. This is a false positive 
because spatial_ref_sys is a PostGIS system table containing only 
coordinate reference system definitions — no user data.

When users try to resolve it by running:
ALTER TABLE public.spatial_ref_sys ENABLE ROW LEVEL SECURITY

They get: ERROR: 42501: must be owner of table spatial_ref_sys

So the warning cannot be dismissed and users are left with a 
permanent critical security alert they cannot fix.

Fixes #125

## What is the new behavior?

Known PostGIS system tables (spatial_ref_sys, geometry_columns, 
geography_columns, raster_columns, raster_overviews) are excluded 
from the RLS check. Users with PostGIS enabled will no longer see 
a false positive critical security warning for these tables.

## Additional context

PostGIS creates these tables in the public schema by default and 
does not support SET SCHEMA, so moving them to a different schema 
is also not possible. Excluding them by name is the correct fix.

Referenced issue: #125
