### PR TITLE
feat: detect and protect if pg_grapqhl on

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -52,7 +52,7 @@ else
 fi
 
 # Execute the test fixtures
-psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -f lints/0025*.sql -d contrib_regression
+psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -f lints/0025*.sql -f lints/0026*.sql -d contrib_regression
 
 # Run tests
 ${REGRESS} --use-existing --dbname=contrib_regression --inputdir=${TESTDIR} ${TESTS}

--- a/docs/0026_pg_graphql_anon_table_exposed.md
+++ b/docs/0026_pg_graphql_anon_table_exposed.md
@@ -1,0 +1,122 @@
+
+**Level:** WARN
+
+**Summary:** Tables readable by the `anon` role leak their schema (table names, columns, relationships) through `pg_graphql` introspection.
+
+**Ramification:** Anyone with your public anon key can enumerate every table the `anon` role can SELECT — even when RLS is enabled. RLS hides rows; it does not hide the schema. This is schema reconnaissance: every table name, column name, type, relationship, and mutation endpoint becomes public knowledge.
+
+---
+
+### Rationale
+
+`pg_graphql` introspection results reflect the Postgres privileges of the calling role. The Supabase anon key maps to the `anon` Postgres role. If `anon` can `SELECT` a table, the table is visible in the GraphQL introspection response from `/graphql/v1`, regardless of RLS. The PostgREST Data API blocks schema inspection without a service role key, but `pg_graphql` does not — its introspection is governed entirely by `GRANT` / `REVOKE`.
+
+You can confirm the leak using only the public anon key:
+
+```bash
+curl -X POST https://<PROJECT_REF>.supabase.co/graphql/v1 \
+  -H 'apiKey: <ANON_KEY>' \
+  -H 'Authorization: Bearer <ANON_KEY>' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"query": "{ __schema { types { name fields { name } } } }"}'
+```
+
+The response includes one entry per exposed table (e.g. `internal_api_keysCollection`, `ordersCollection`), the full column list for each table, and `Mutation` entries like `insertIntointernal_api_keysCollection`, `updateinternal_api_keysCollection`, `deleteFrominternal_api_keysCollection`.
+
+### How to Resolve
+
+The fix is always a standard Postgres `GRANT` / `REVOKE` run in the SQL Editor. No support ticket, no config file, no extension toggle.
+
+**Option 1: Hide every table from `anon` (most thorough)**
+
+```sql
+revoke all on all tables in schema public from anon;
+```
+
+Then prevent future tables from auto-exposing:
+
+```sql
+alter default privileges in schema public
+  revoke select on tables from anon;
+```
+
+Re-grant access to `authenticated` for tables your app needs after login:
+
+```sql
+grant select on public.profiles to authenticated;
+grant select on public.products to authenticated;
+grant select, insert on public.orders to authenticated;
+-- Sensitive tables receive no grant and remain invisible to introspection.
+```
+
+**Option 2: Hide a specific sensitive table only**
+
+```sql
+revoke all on public.internal_api_keys from anon;
+```
+
+`anon` continues to see other tables, but `internal_api_keys` disappears from introspection.
+
+**Option 3: Block the entire GraphQL endpoint for `anon`**
+
+```sql
+revoke all on function graphql.resolve from anon;
+```
+
+This rejects every unauthenticated GraphQL request, not just introspection. Use only if you do not need GraphQL for unauthenticated users at all. The table-level revokes above are usually preferable because they keep the endpoint alive while returning an empty schema.
+
+### Example
+
+Given a table that anyone can read via the anon key:
+
+```sql
+create table public.internal_api_keys(
+    id uuid primary key,
+    service text,
+    key_hash text,
+    permissions jsonb,
+    last_used timestamptz,
+    created_by uuid
+);
+
+alter table public.internal_api_keys enable row level security;
+-- No policies, but anon still inherits the default SELECT grant.
+```
+
+Even though RLS is enabled and no rows are returned, every column name above is now visible through `/graphql/v1` introspection.
+
+Fix:
+
+```sql
+revoke all on public.internal_api_keys from anon;
+```
+
+Re-running the introspection query no longer returns this table.
+
+### Verifying the Fix
+
+After applying the revoke, the introspection query's `Query` type should contain only `{"name": "node"}` (when every table has been hidden) or omit the specific table you revoked. Authenticated users with a valid JWT continue to see only the tables explicitly granted to the `authenticated` role:
+
+```bash
+curl -X POST https://<PROJECT_REF>.supabase.co/graphql/v1 \
+  -H 'apiKey: <ANON_KEY>' \
+  -H 'Authorization: Bearer <USER_JWT>' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"query": "{ __schema { types { name fields { name } } } }"}'
+```
+
+### Quick Reference
+
+| Goal | SQL |
+|------|-----|
+| Hide one table from `anon` | `revoke all on public.secret_table from anon;` |
+| Hide all tables from `anon` | `revoke all on all tables in schema public from anon;` |
+| Prevent future auto-grants | `alter default privileges in schema public revoke select on tables from anon;` |
+| Kill GraphQL endpoint for `anon` | `revoke all on function graphql.resolve from anon;` |
+| Grant a table to `authenticated` | `grant select on public.my_table to authenticated;` |
+
+### False Positives
+
+This lint flags every `anon`-readable table when `pg_graphql` is installed. Some of these are intentional — public catalog tables (blog posts, product listings, public FAQs) are meant to be readable without authentication, and exposing their column names is acceptable.
+
+If introspection visibility is intentional for a table, the lint can be safely ignored for that table. The lint is informational rather than a hard misconfiguration: it surfaces what your project leaks so you can decide which tables are actually meant to be public.

--- a/lints/0026_pg_graphql_anon_table_exposed.sql
+++ b/lints/0026_pg_graphql_anon_table_exposed.sql
@@ -1,0 +1,56 @@
+create view lint."0026_pg_graphql_anon_table_exposed" as
+
+-- Detects tables whose schema is leaked through pg_graphql introspection.
+-- pg_graphql introspection reflects the calling role's Postgres privileges:
+-- if `anon` can SELECT a table, the table name, columns, and relationships
+-- are visible to anyone with the public anon key via /graphql/v1, even when
+-- RLS is enabled.
+with graphql_installed as (
+    select 1 as installed
+    from pg_catalog.pg_extension
+    where extname = 'pg_graphql'
+),
+exposed_tables as (
+    select
+        n.nspname as schema_name,
+        c.relname as table_name
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind in ('r', 'p') -- regular or partitioned tables
+        and pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        and exists (select 1 from graphql_installed)
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+)
+select
+    'pg_graphql_anon_table_exposed' as name,
+    'pg_graphql Anon Role Exposes Tables in Introspection' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables whose schema is leaked via the public `/graphql/v1` introspection endpoint. When `pg_graphql` is installed, any table the `anon` role has `SELECT` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled.' as description,
+    format(
+        'Extension `pg_graphql` is installed and the `anon` role has `SELECT` on `%s.%s`. The table''s name, columns, and relationships are visible via the public `/graphql/v1` introspection endpoint.',
+        schema_name,
+        table_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'pg_graphql_anon_table_exposed_%s_%s',
+        schema_name,
+        table_name
+    ) as cache_key
+from
+    exposed_tables
+order by
+    schema_name,
+    table_name;

--- a/splinter.sql
+++ b/splinter.sql
@@ -1482,3 +1482,59 @@ from
     affected_buckets
 order by
     bucket_id)
+union all
+(
+-- Detects tables whose schema is leaked through pg_graphql introspection.
+-- pg_graphql introspection reflects the calling role's Postgres privileges:
+-- if `anon` can SELECT a table, the table name, columns, and relationships
+-- are visible to anyone with the public anon key via /graphql/v1, even when
+-- RLS is enabled.
+with graphql_installed as (
+    select 1 as installed
+    from pg_catalog.pg_extension
+    where extname = 'pg_graphql'
+),
+exposed_tables as (
+    select
+        n.nspname as schema_name,
+        c.relname as table_name
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind in ('r', 'p') -- regular or partitioned tables
+        and pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        and exists (select 1 from graphql_installed)
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+)
+select
+    'pg_graphql_anon_table_exposed' as name,
+    'pg_graphql Anon Role Exposes Tables in Introspection' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables whose schema is leaked via the public `/graphql/v1` introspection endpoint. When `pg_graphql` is installed, any table the `anon` role has `SELECT` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled.' as description,
+    format(
+        'Extension `pg_graphql` is installed and the `anon` role has `SELECT` on `%s.%s`. The table''s name, columns, and relationships are visible via the public `/graphql/v1` introspection endpoint.',
+        schema_name,
+        table_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table'
+    ) as metadata,
+    format(
+        'pg_graphql_anon_table_exposed_%s_%s',
+        schema_name,
+        table_name
+    ) as cache_key
+from
+    exposed_tables
+order by
+    schema_name,
+    table_name)

--- a/test/expected/0026_pg_graphql_anon_table_exposed.out
+++ b/test/expected/0026_pg_graphql_anon_table_exposed.out
@@ -1,0 +1,49 @@
+begin;
+  set local search_path = '';
+  -- BASELINE: pg_graphql not installed, no rows
+  select * from lint."0026_pg_graphql_anon_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  savepoint a;
+  ----------------------------------------
+  -- NEGATIVE EXAMPLE: anon has SELECT on a table but pg_graphql is NOT installed.
+  -- Without the extension there is no /graphql/v1 endpoint, so no introspection leak.
+  ----------------------------------------
+  create table public.products(id int primary key, name text);
+  -- Default privileges from fixtures grant SELECT on new public tables to PUBLIC,
+  -- so `anon` already has SELECT here. The lint must still report 0 rows.
+  select * from lint."0026_pg_graphql_anon_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint a;
+  ----------------------------------------
+  -- POSITIVE EXAMPLE: pg_graphql IS installed and `anon` has SELECT on a public table.
+  -- The table's schema (name, columns, relationships) leaks via /graphql/v1 introspection.
+  ----------------------------------------
+  create extension pg_graphql;
+  create table public.internal_api_keys(
+    id int primary key,
+    service text,
+    key_hash text
+  );
+  select name, detail, cache_key from lint."0026_pg_graphql_anon_table_exposed";
+             name              |                                                                                                      detail                                                                                                       |                       cache_key                        
+-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------
+ pg_graphql_anon_table_exposed | Extension `pg_graphql` is installed and the `anon` role has `SELECT` on `public.internal_api_keys`. The table's name, columns, and relationships are visible via the public `/graphql/v1` introspection endpoint. | pg_graphql_anon_table_exposed_public_internal_api_keys
+(1 row)
+
+  ----------------------------------------
+  -- RESOLUTION: revoke from anon and from public (default privileges granted to public).
+  -- After revoking, has_table_privilege('anon', ...) is false and the lint clears.
+  ----------------------------------------
+  revoke all on public.internal_api_keys from anon, public;
+  select * from lint."0026_pg_graphql_anon_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+rollback;

--- a/test/expected/queries_are_unionable.out
+++ b/test/expected/queries_are_unionable.out
@@ -46,7 +46,9 @@ begin;
     union all
     select * from lint."0024_rls_policy_always_true"
     union all
-    select * from lint."0025_public_bucket_allows_listing";
+    select * from lint."0025_public_bucket_allows_listing"
+    union all
+    select * from lint."0026_pg_graphql_anon_table_exposed";
  name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
 ------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
 (0 rows)

--- a/test/sql/0026_pg_graphql_anon_table_exposed.sql
+++ b/test/sql/0026_pg_graphql_anon_table_exposed.sql
@@ -1,0 +1,40 @@
+begin;
+  set local search_path = '';
+
+  -- BASELINE: pg_graphql not installed, no rows
+  select * from lint."0026_pg_graphql_anon_table_exposed";
+
+  savepoint a;
+
+  ----------------------------------------
+  -- NEGATIVE EXAMPLE: anon has SELECT on a table but pg_graphql is NOT installed.
+  -- Without the extension there is no /graphql/v1 endpoint, so no introspection leak.
+  ----------------------------------------
+  create table public.products(id int primary key, name text);
+  -- Default privileges from fixtures grant SELECT on new public tables to PUBLIC,
+  -- so `anon` already has SELECT here. The lint must still report 0 rows.
+  select * from lint."0026_pg_graphql_anon_table_exposed";
+
+  rollback to savepoint a;
+
+  ----------------------------------------
+  -- POSITIVE EXAMPLE: pg_graphql IS installed and `anon` has SELECT on a public table.
+  -- The table's schema (name, columns, relationships) leaks via /graphql/v1 introspection.
+  ----------------------------------------
+  create extension pg_graphql;
+  create table public.internal_api_keys(
+    id int primary key,
+    service text,
+    key_hash text
+  );
+
+  select name, detail, cache_key from lint."0026_pg_graphql_anon_table_exposed";
+
+  ----------------------------------------
+  -- RESOLUTION: revoke from anon and from public (default privileges granted to public).
+  -- After revoking, has_table_privilege('anon', ...) is false and the lint clears.
+  ----------------------------------------
+  revoke all on public.internal_api_keys from anon, public;
+  select * from lint."0026_pg_graphql_anon_table_exposed";
+
+rollback;

--- a/test/sql/queries_are_unionable.sql
+++ b/test/sql/queries_are_unionable.sql
@@ -48,6 +48,8 @@ begin;
     union all
     select * from lint."0024_rls_policy_always_true"
     union all
-    select * from lint."0025_public_bucket_allows_listing";
+    select * from lint."0025_public_bucket_allows_listing"
+    union all
+    select * from lint."0026_pg_graphql_anon_table_exposed";
 
 rollback;


### PR DESCRIPTION
Added a WARN-level security lint that fires when both:

pg_graphql extension is installed (the /graphql/v1 endpoint exists), and
the anon role has SELECT on a user-schema table
For each matching table, the lint reports the schema/table and links to the
new doc page that walks through the full Introspection Lockdown Guide
(table-level revoke, blanket revoke, default-privileges fix, graphql.resolve
revoke, and authenticated re-grant pattern).

Files

lints/0026_pg_graphql_anon_table_exposed.sql — view in lint schema; uses
pg_catalog.has_table_privilege('anon', oid, 'SELECT') gated by an EXISTS
against pg_extension
docs/0026_pg_graphql_anon_table_exposed.md — full guide (rationale, options
1–3, example, verification, quick reference, false-positive note)
test/sql/0026_pg_graphql_anon_table_exposed.sql + test/expected/0026_…out —
baseline / negative (no extension) / positive (extension + anon SELECT) /
resolution (revoke)
bin/installcheck — added -f lints/0026*.sql
test/sql/queries_are_unionable.sql + expected — added new view to the union
check
splinter.sql — regenerated via bin/compile.py
Test result: All 25 tests passed. on supabase/postgres:15.1.1.13.