### PR TITLE
Pg graphql authenticated table and other updates

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -52,7 +52,7 @@ else
 fi
 
 # Execute the test fixtures
-psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -f lints/0025*.sql -f lints/0026*.sql -d contrib_regression
+psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -f lints/0025*.sql -f lints/0026*.sql -f lints/0027*.sql -f lints/0028*.sql -f lints/0029*.sql -d contrib_regression
 
 # Run tests
 ${REGRESS} --use-existing --dbname=contrib_regression --inputdir=${TESTDIR} ${TESTS}

--- a/docs/0026_pg_graphql_anon_table_exposed.md
+++ b/docs/0026_pg_graphql_anon_table_exposed.md
@@ -1,15 +1,35 @@
 
 **Level:** WARN
 
-**Summary:** Tables and views readable by the `anon` role have their schema (names, columns, relationships) made visible through `pg_graphql` introspection.
+**Summary:** Tables, views, materialized views, and foreign tables readable by the `anon` role have their schema (names, columns, relationships) made visible through `pg_graphql` introspection.
 
-**Ramification:** Anyone with your public anon key can enumerate every table and view the `anon` role can SELECT — even when RLS is enabled. RLS hides rows; it does not hide the schema. Both forms of introspection (PostgREST and `pg_graphql`) are intentional behavior, but you may not realize how much of your schema is reachable without authentication: every table name, column name, type, relationship, and mutation endpoint is publicly discoverable.
+**Ramification:** Anyone with your public anon key can enumerate every relation the `anon` role can SELECT — even when RLS is enabled. RLS hides rows; it does not hide the schema. Both forms of introspection (PostgREST and `pg_graphql`) are intentional behavior, but you may not realize how much of your schema is reachable without authentication: every table name, column name, type, relationship, and mutation endpoint is publicly discoverable.
+
+> **See also: lint [0027_pg_graphql_authenticated_table_exposed](0027_pg_graphql_authenticated_table_exposed.md).** In default Supabase projects `anon` and `authenticated` start with identical default-privilege grants, so revoking from `anon` alone often leaves the same introspection response served to any signed-up user. Address findings from both lints together.
+
+---
+
+### If you are not using `pg_graphql`, disable it
+
+The simplest mitigation — and the right one if your app does not use the GraphQL endpoint — is to drop the extension. With `pg_graphql` not installed, this lint and 0027 stop firing entirely and the `/graphql/v1` endpoint returns nothing exposing your schema.
+
+In the Supabase SQL Editor:
+
+```sql
+drop extension pg_graphql;
+```
+
+Or in the dashboard: **Database → Extensions**, search for `pg_graphql`, and toggle it off.
+
+If your project does use `pg_graphql`, leave it installed and follow the remediation below.
 
 ---
 
 ### Rationale
 
-`pg_graphql` introspection is by design: the GraphQL schema reflects the Postgres privileges of the calling role. The Supabase anon key maps to the `anon` Postgres role, so any table or view `anon` can `SELECT` is visible in the GraphQL introspection response from `/graphql/v1`, regardless of RLS. Visibility through introspection is governed entirely by `GRANT` / `REVOKE`. This lint flags the objects that are currently discoverable so you can confirm each one is intentionally public.
+`pg_graphql` introspection is by design: the GraphQL schema reflects the Postgres privileges of the calling role. The Supabase anon key maps to the `anon` Postgres role, so any relation `anon` can `SELECT` is visible in the GraphQL introspection response from `/graphql/v1`, regardless of RLS. Visibility through introspection is governed entirely by `GRANT` / `REVOKE`. This lint flags the objects currently discoverable through the public anon key so you can confirm each one is intentionally public.
+
+The relkinds covered match `pg_graphql`'s own filter (`load_sql_context.sql:395-400`): regular tables (`r`), views (`v`), materialized views (`m`), and foreign tables (`f`). Partitioned table roots (`relkind='p'`) are not covered because `pg_graphql` does not expose them via introspection; their leaf partitions (`relkind='r'`) are still picked up individually.
 
 You can confirm what is visible using only the public anon key:
 
@@ -26,6 +46,8 @@ The response includes one entry per exposed table (e.g. `internal_api_keysCollec
 ### How to Resolve
 
 The fix is always a standard Postgres `GRANT` / `REVOKE` run in the SQL Editor. No support ticket, no config file, no extension toggle.
+
+**Important:** revoking from `anon` does not, on its own, hide the relation from `pg_graphql` introspection — `authenticated` is checked separately by lint 0027 and typically has the same default grants. Address both lints' findings together (see "Hide all tables from both roles" in 0027).
 
 **Option 1: Hide every table from `anon` (most thorough)**
 
@@ -46,7 +68,9 @@ Re-grant access to `authenticated` for tables your app needs after login:
 grant select on public.profiles to authenticated;
 grant select on public.products to authenticated;
 grant select, insert on public.orders to authenticated;
--- Sensitive tables receive no grant and remain invisible to introspection.
+-- Sensitive tables receive no grant from anon and remain invisible to
+-- the public introspection endpoint. Make sure to also handle 0027 for
+-- the authenticated-side exposure.
 ```
 
 **Option 2: Hide a specific sensitive table or view only**
@@ -55,7 +79,7 @@ grant select, insert on public.orders to authenticated;
 revoke all on public.internal_api_keys from anon;
 ```
 
-`anon` continues to see other objects, but `internal_api_keys` is no longer visible in introspection. Use the same `revoke all on <object>` pattern for views and materialized views.
+`anon` continues to see other objects, but `internal_api_keys` is no longer visible in the unauthenticated introspection response. Use the same `revoke all on <object>` pattern for views, materialized views, and foreign tables.
 
 **Option 3: Block the entire GraphQL endpoint for `anon`**
 
@@ -91,7 +115,7 @@ Fix:
 revoke all on public.internal_api_keys from anon;
 ```
 
-Re-running the introspection query no longer returns this table.
+Re-running the introspection query with the anon key no longer returns this table. (The same call repeated with a signed-up user's JWT still returns it until you also revoke from `authenticated` — see 0027.)
 
 ### Verifying the Fix
 
@@ -117,6 +141,6 @@ curl -X POST https://<PROJECT_REF>.supabase.co/graphql/v1 \
 
 ### False Positives
 
-This lint flags every `anon`-readable table when `pg_graphql` is installed. Some of these are intentional — public catalog tables (blog posts, product listings, public FAQs) are meant to be readable without authentication, and exposing their column names is acceptable.
+This lint flags every `anon`-readable relation when `pg_graphql` is installed. Some of these are intentional — public catalog tables (blog posts, product listings, public FAQs) are meant to be readable without authentication, and exposing their column names is acceptable.
 
-If introspection visibility is intentional for a table or view, the lint can be safely ignored for that object. The lint is informational rather than a hard misconfiguration: it surfaces what your project makes visible so you can decide which tables and views are actually meant to be public.
+If introspection visibility is intentional for a relation, the lint can be safely ignored for that object. The lint is informational rather than a hard misconfiguration: it surfaces what your project makes visible so you can decide which relations are actually meant to be public.

--- a/docs/0027_pg_graphql_authenticated_table_exposed.md
+++ b/docs/0027_pg_graphql_authenticated_table_exposed.md
@@ -1,0 +1,138 @@
+
+**Level:** WARN
+
+**Summary:** Tables, views, materialized views, and foreign tables readable by the `authenticated` role have their schema (names, columns, relationships) made visible through `pg_graphql` introspection to any signed-up user.
+
+**Ramification:** Every relation the `authenticated` role can SELECT is enumerable by anyone with a valid Supabase user JWT — even when RLS is enabled. RLS hides rows; it does not hide the schema. In default Supabase projects the `authenticated` role starts with the same default-privilege grants as `anon` (both come from `ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin … TO anon, authenticated, service_role`), and under open or auto-confirm signup, "authenticated" is in practice anyone with a throwaway email rather than a meaningfully smaller audience.
+
+> **See also: lint [0026_pg_graphql_anon_table_exposed](0026_pg_graphql_anon_table_exposed.md).** The two checks are paired — revoking from one role alone usually leaves the other side of the introspection response unchanged. Address findings from both lints together.
+
+---
+
+### If you are not using `pg_graphql`, disable it
+
+The simplest mitigation — and the right one if your app does not use the GraphQL endpoint — is to drop the extension. With `pg_graphql` not installed, this lint and 0026 stop firing entirely and the `/graphql/v1` endpoint returns nothing exposing your schema.
+
+In the Supabase SQL Editor:
+
+```sql
+drop extension pg_graphql;
+```
+
+Or in the dashboard: **Database → Extensions**, search for `pg_graphql`, and toggle it off.
+
+If your project does use `pg_graphql`, leave it installed and follow the remediation below.
+
+---
+
+### Rationale
+
+`pg_graphql` introspection runs under whichever role the caller's JWT claims, not specifically `anon`. A request with the public anon key runs as `anon`; a request with a real user JWT runs as `authenticated`. The introspection response reflects the privileges of that role.
+
+That makes the documented remediation for 0026 — "revoke from `anon`, grant to `authenticated`" — incomplete on its own. Because the two roles share identical default-privilege grants, an operator who follows the 0026 doc verbatim can clear that lint and still see the `/graphql/v1` introspection response served to any signed-up user remain byte-for-byte unchanged. Lint 0027 catches that case: it fires whenever `authenticated` has `SELECT` on a relation that `pg_graphql` would expose.
+
+The relkinds covered match `pg_graphql`'s own filter (`load_sql_context.sql:395-400`): regular tables (`r`), views (`v`), materialized views (`m`), and foreign tables (`f`). Partitioned table roots (`relkind='p'`) are not covered because `pg_graphql` does not expose them via introspection; their leaf partitions (`relkind='r'`) are still picked up individually.
+
+You can confirm what is visible to authenticated users by repeating the introspection request with a real user JWT in the `Authorization` header:
+
+```bash
+curl -X POST https://<PROJECT_REF>.supabase.co/graphql/v1 \
+  -H 'apiKey: <ANON_KEY>' \
+  -H 'Authorization: Bearer <USER_JWT>' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"query": "{ __schema { types { name fields { name } } } }"}'
+```
+
+### How to Resolve
+
+The fix is a standard Postgres `GRANT` / `REVOKE`. Unlike 0026, you cannot simply revoke from `authenticated` — your app probably needs `authenticated` to read most tables. The right move is per-relation: keep grants on the tables signed-up users genuinely need, and revoke from the rest.
+
+**Option 1: Audit and revoke per-relation (recommended)**
+
+```sql
+-- A relation that should never be visible to signed-up users:
+revoke all on public.internal_api_keys from authenticated, anon, public;
+
+-- A relation that signed-up users do need; introspection visibility is
+-- intentional and the lint can be ignored for this object:
+grant select on public.profiles to authenticated;
+```
+
+Walk the 0027 findings list; for each relation, decide whether `authenticated` visibility is intentional. If it is, suppress the finding for that object. If it is not, revoke.
+
+**Option 2: Hide every table from both roles, re-grant only what is needed**
+
+```sql
+revoke all on all tables in schema public from anon, authenticated;
+
+alter default privileges in schema public
+  revoke select on tables from anon, authenticated;
+
+-- Re-grant per-relation only where genuinely required:
+grant select on public.profiles to authenticated;
+grant select on public.products to authenticated;
+grant select, insert on public.orders to authenticated;
+```
+
+This pairs cleanly with 0026's Option 1 and is the cleanest end state for projects that want introspection to expose only an explicit allowlist.
+
+**Option 3: Block the entire GraphQL endpoint for both roles**
+
+```sql
+revoke all on function graphql.resolve from anon, authenticated;
+```
+
+This rejects every GraphQL request, not just introspection. Use only if you do not use the `/graphql/v1` endpoint at all. The table-level revokes above are usually preferable because they keep the endpoint alive while returning an empty schema.
+
+### Example
+
+Given a table that signed-up users should not be able to see in introspection:
+
+```sql
+create table public.internal_api_keys(
+    id uuid primary key,
+    service text,
+    key_hash text,
+    permissions jsonb
+);
+
+alter table public.internal_api_keys enable row level security;
+-- No policies, but `authenticated` still inherits the default SELECT
+-- grant — every signed-up user sees the column list via introspection.
+```
+
+Lint 0027 fires for `public.internal_api_keys`. Fix:
+
+```sql
+revoke all on public.internal_api_keys from authenticated, anon, public;
+```
+
+The introspection query no longer returns this table for any role. (If 0026 was also firing for this table, the same revoke clears it.)
+
+### Verifying the Fix
+
+After applying the revoke, repeat the introspection query with a real user JWT and confirm the relation is no longer in the response:
+
+```bash
+curl -X POST https://<PROJECT_REF>.supabase.co/graphql/v1 \
+  -H 'apiKey: <ANON_KEY>' \
+  -H 'Authorization: Bearer <USER_JWT>' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"query": "{ __schema { types { name fields { name } } } }"}'
+```
+
+### Quick Reference
+
+| Goal | SQL |
+|------|-----|
+| Hide one table from `authenticated` | `revoke all on public.secret_table from authenticated, public;` |
+| Hide all tables from `authenticated` | `revoke all on all tables in schema public from authenticated;` |
+| Prevent future auto-grants | `alter default privileges in schema public revoke select on tables from authenticated;` |
+| Hide one table from both roles | `revoke all on public.secret_table from anon, authenticated, public;` |
+| Kill GraphQL endpoint for both roles | `revoke all on function graphql.resolve from anon, authenticated;` |
+
+### False Positives
+
+This lint flags every `authenticated`-readable relation when `pg_graphql` is installed. The majority of findings are usually intentional — most app-facing tables genuinely need to be readable by signed-up users, and exposing their column names through introspection is acceptable.
+
+If introspection visibility is intentional for a relation, the lint can be safely ignored for that object. The lint is informational: it surfaces what your project makes visible to authenticated users so you can decide which relations are actually meant to be discoverable by every account holder, including throwaway accounts created via open signup.

--- a/docs/0028_anon_security_definer_function_executable.md
+++ b/docs/0028_anon_security_definer_function_executable.md
@@ -1,0 +1,97 @@
+
+**Level:** WARN
+
+**Summary:** A `SECURITY DEFINER` function in a user schema is executable by the `anon` role, meaning anyone with the public anon key can invoke a privileged operation that bypasses RLS.
+
+**Ramification:** A `SECURITY DEFINER` function runs with the privileges of its owner — typically a role with `BYPASSRLS` or with broad table grants — not the caller. When `anon` has `EXECUTE`, any unauthenticated request can call the function via `POST /rest/v1/rpc/<name>` and read or modify rows that RLS would otherwise hide. If pg_graphql is installed and the function's return type is supported, the same function is also callable as a Query or Mutation field via `/graphql/v1`.
+
+> **See also: lint [0029_authenticated_security_definer_function_executable](0029_authenticated_security_definer_function_executable.md).** In default Supabase projects `anon` and `authenticated` start with identical default-privilege grants (and the Postgres default for new functions is `EXECUTE` to `PUBLIC`), so revoking from `anon` alone usually leaves the same function callable by every signed-up user. Address findings from both lints together. The `pg_graphql_*` lints (0026/0027) cover the parallel risk for tables/views.
+
+---
+
+### If you are not using `pg_graphql`, disable it
+
+Disabling `pg_graphql` closes the `/graphql/v1` Query/Mutation surface, which is one of two ways this function is reachable. **The function is still callable via PostgREST `/rest/v1/rpc/<name>`** — so this lint will continue to fire after the drop, and the remediation below is still required. Disable `pg_graphql` only if your app does not use the GraphQL endpoint; do not treat it as a fix for this lint.
+
+In the Supabase SQL Editor:
+
+```sql
+drop extension pg_graphql;
+```
+
+Or in the dashboard: **Database → Extensions**, search for `pg_graphql`, and toggle it off.
+
+---
+
+### Rationale
+
+Two facts combine to make this a high-impact misconfiguration:
+
+1. **`SECURITY DEFINER` bypasses RLS.** When a function is declared `SECURITY DEFINER`, it executes with the role of its owner, not the caller. The owner is usually a privileged role created by Supabase (for example `postgres` or `supabase_admin`) which can read every row in every RLS-protected table. So calling the function returns rows that the caller — `anon` — could never read with a direct `SELECT`.
+
+2. **Postgres' default function ACL is `EXECUTE` to `PUBLIC`**, and Supabase additionally grants default privileges for new functions to `anon, authenticated, service_role`. So a function created in `public` is, by default, executable by `anon`. The author has to actively revoke to remove that grant.
+
+The result: a developer writes a helper function intending it to be called from an admin script, doesn't think about the API surface, and the function becomes a public exfiltration endpoint. PostgREST exposes it at `/rest/v1/rpc/<name>` automatically; pg_graphql exposes it as a query or mutation field if the return type is supported. The function does not need to appear anywhere in the documented API for the call to work — `/rest/v1/rpc` accepts any function name the role has `EXECUTE` on.
+
+This lint deliberately ignores `SECURITY INVOKER` functions: those run as the caller, so RLS still applies to any tables they touch. They can still be problematic if the *underlying* tables are unprotected, but that risk is covered by lints `0008_rls_enabled_no_policy` and `0013_rls_disabled_in_public` on the data, not by this lint on the function.
+
+### How to Resolve
+
+The fix is per-function. For each finding, decide whether `anon` should genuinely be able to invoke the operation, then take one of three paths:
+
+**Option 1: Revoke `EXECUTE` (most common)**
+
+```sql
+revoke execute on function public.my_priv_op(int, text) from anon, public;
+```
+
+You almost always want to revoke from `PUBLIC` as well, because Postgres' default-grant lives there. Repeat for `authenticated` if that lint also fires (or do both at once: see lint 0029).
+
+**Option 2: Keep the function exposed but switch to `SECURITY INVOKER`**
+
+```sql
+alter function public.my_priv_op(int, text) security invoker;
+```
+
+The function still runs, but it now executes as the caller. RLS on the underlying tables takes effect, and the operator can model access through policies instead of through an unrestricted `EXECUTE`. Suitable when the function does not actually need to bypass RLS — it was just declared `SECURITY DEFINER` by habit or default.
+
+**Option 3: Keep both `SECURITY DEFINER` and the `EXECUTE` grant — intentional**
+
+Some functions are deliberately exposed: a "submit contact form" function that `INSERT`s into a table the caller cannot otherwise write to, a public RPC that returns the count of public posts, etc. If the lint flags one of these, the finding is intentional and can be suppressed for that object. The function should validate inputs and limit what it does — a `SECURITY DEFINER` exposed to `anon` is effectively a public API endpoint.
+
+### Identifying the Owner
+
+To see who the function actually runs as (this is what determines what RLS it bypasses):
+
+```sql
+select
+    p.proname,
+    pg_get_function_identity_arguments(p.oid) as args,
+    pg_catalog.pg_get_userbyid(p.proowner) as owner,
+    p.prosecdef as security_definer
+from pg_catalog.pg_proc p
+join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and p.prosecdef
+order by p.proname;
+```
+
+If the owner is a high-privilege role, the function can read and write everything that role can.
+
+### Quick Reference
+
+| Goal | SQL |
+|------|-----|
+| Hide one function from `anon` | `revoke execute on function public.f(int) from anon, public;` |
+| Hide all functions in a schema from `anon` | `revoke execute on all functions in schema public from anon;` |
+| Prevent future auto-grants of EXECUTE | `alter default privileges in schema public revoke execute on functions from anon, public;` |
+| Switch a function to caller's privileges | `alter function public.f(int) security invoker;` |
+
+### False Positives
+
+This lint flags every `SECURITY DEFINER` function in a user schema with `EXECUTE` granted to `anon`. There are two situations where the finding is not a real risk:
+
+- **The function is intentionally a public API endpoint.** A "rate-limited contact form" or "anonymous vote" function is meant to be `SECURITY DEFINER` (so it can write to a table `anon` cannot otherwise write to) and meant to be executable by `anon`. Confirm the function validates input and limits what it does, then suppress.
+- **The owner is a low-privilege role.** If the function's owner has no more privileges than the caller, `SECURITY DEFINER` does not actually escalate. This is rare because Supabase functions are typically owned by a privileged role, but worth checking the owner column shown above.
+
+In every other case the lint is reporting a real privilege escalation: a caller with the public anon key can run code that reads or writes data they otherwise could not.

--- a/docs/0029_authenticated_security_definer_function_executable.md
+++ b/docs/0029_authenticated_security_definer_function_executable.md
@@ -1,0 +1,98 @@
+
+**Level:** WARN
+
+**Summary:** A `SECURITY DEFINER` function in a user schema is executable by the `authenticated` role, meaning every signed-up user can invoke a privileged operation that bypasses RLS.
+
+**Ramification:** A `SECURITY DEFINER` function runs with the privileges of its owner — typically a role with `BYPASSRLS` or with broad table grants — not the caller. When `authenticated` has `EXECUTE`, any signed-up user can call the function via `POST /rest/v1/rpc/<name>` with a real user JWT and read or modify rows that RLS would otherwise hide. If pg_graphql is installed and the function's return type is supported, the same function is also callable as a Query or Mutation field via `/graphql/v1`. Under open or auto-confirm signup, "authenticated" is anyone with a throwaway email — not a meaningfully smaller audience than `anon`.
+
+> **See also: lint [0028_anon_security_definer_function_executable](0028_anon_security_definer_function_executable.md).** The two checks are paired — revoking from one role alone usually leaves the other side callable. Address findings from both lints together. The `pg_graphql_*` lints (0026/0027) cover the parallel risk for tables/views.
+
+---
+
+### If you are not using `pg_graphql`, disable it
+
+Disabling `pg_graphql` closes the `/graphql/v1` Query/Mutation surface, which is one of two ways this function is reachable. **The function is still callable via PostgREST `/rest/v1/rpc/<name>`** — so this lint will continue to fire after the drop, and the remediation below is still required. Disable `pg_graphql` only if your app does not use the GraphQL endpoint; do not treat it as a fix for this lint.
+
+In the Supabase SQL Editor:
+
+```sql
+drop extension pg_graphql;
+```
+
+Or in the dashboard: **Database → Extensions**, search for `pg_graphql`, and toggle it off.
+
+---
+
+### Rationale
+
+Two facts combine to make this a high-impact misconfiguration:
+
+1. **`SECURITY DEFINER` bypasses RLS.** When a function is declared `SECURITY DEFINER`, it executes with the role of its owner, not the caller. The owner is usually a privileged role created by Supabase (for example `postgres` or `supabase_admin`) which can read every row in every RLS-protected table. So calling the function returns rows that the caller — `authenticated` — could never read with a direct `SELECT`.
+
+2. **Postgres' default function ACL is `EXECUTE` to `PUBLIC`**, and Supabase additionally grants default privileges for new functions to `anon, authenticated, service_role`. So a function created in `public` is, by default, executable by `authenticated`. The author has to actively revoke to remove that grant.
+
+The result: a developer writes a helper function intending it to be called from an admin script, doesn't think about the API surface, and the function becomes an exfiltration endpoint for any signed-up user. PostgREST exposes it at `/rest/v1/rpc/<name>` automatically; pg_graphql exposes it as a query or mutation field if the return type is supported. The function does not need to appear anywhere in the documented API for the call to work — `/rest/v1/rpc` accepts any function name the role has `EXECUTE` on. Because Supabase signup is often open or email-auto-confirm, the audience for `authenticated` is effectively the public internet.
+
+This lint deliberately ignores `SECURITY INVOKER` functions: those run as the caller, so RLS still applies to any tables they touch. They can still be problematic if the *underlying* tables are unprotected, but that risk is covered by lints `0008_rls_enabled_no_policy` and `0013_rls_disabled_in_public` on the data, not by this lint on the function.
+
+### How to Resolve
+
+The fix is per-function. For each finding, decide whether `authenticated` should genuinely be able to invoke the operation, then take one of three paths:
+
+**Option 1: Revoke `EXECUTE` (most common)**
+
+```sql
+revoke execute on function public.my_priv_op(int, text) from authenticated, anon, public;
+```
+
+Revoke from `PUBLIC` as well, because Postgres' default-grant lives there. Revoking from `anon` at the same time also clears the matching 0028 finding.
+
+**Option 2: Keep the function exposed but switch to `SECURITY INVOKER`**
+
+```sql
+alter function public.my_priv_op(int, text) security invoker;
+```
+
+The function still runs, but it now executes as the caller. RLS on the underlying tables takes effect, and the operator can model access through policies instead of through an unrestricted `EXECUTE`. Suitable when the function does not actually need to bypass RLS — it was just declared `SECURITY DEFINER` by habit or default.
+
+**Option 3: Keep both `SECURITY DEFINER` and the `EXECUTE` grant — intentional**
+
+Some functions are deliberately exposed to signed-up users: a "create my profile" function that initialises rows the user cannot otherwise insert, a "submit feedback" function that writes to a table they cannot otherwise write to, etc. If the lint flags one of these, the finding is intentional and can be suppressed for that object. The function should validate inputs and limit what it does — a `SECURITY DEFINER` exposed to `authenticated` is effectively a public API endpoint to anyone who can sign up.
+
+### Identifying the Owner
+
+To see who the function actually runs as (this is what determines what RLS it bypasses):
+
+```sql
+select
+    p.proname,
+    pg_get_function_identity_arguments(p.oid) as args,
+    pg_catalog.pg_get_userbyid(p.proowner) as owner,
+    p.prosecdef as security_definer
+from pg_catalog.pg_proc p
+join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and p.prosecdef
+order by p.proname;
+```
+
+If the owner is a high-privilege role, the function can read and write everything that role can.
+
+### Quick Reference
+
+| Goal | SQL |
+|------|-----|
+| Hide one function from `authenticated` | `revoke execute on function public.f(int) from authenticated, public;` |
+| Hide one function from both roles | `revoke execute on function public.f(int) from anon, authenticated, public;` |
+| Hide all functions in a schema from `authenticated` | `revoke execute on all functions in schema public from authenticated;` |
+| Prevent future auto-grants of EXECUTE | `alter default privileges in schema public revoke execute on functions from anon, authenticated, public;` |
+| Switch a function to caller's privileges | `alter function public.f(int) security invoker;` |
+
+### False Positives
+
+This lint flags every `SECURITY DEFINER` function in a user schema with `EXECUTE` granted to `authenticated`. There are two situations where the finding is not a real risk:
+
+- **The function is intentionally a per-user privileged operation.** A "register my account profile" or "submit feedback as me" function may be `SECURITY DEFINER` (so it can write to a table `authenticated` cannot otherwise write to) and meant to be executable by every signed-up user. Confirm the function validates input and limits what it does, then suppress.
+- **The owner is a low-privilege role.** If the function's owner has no more privileges than the caller, `SECURITY DEFINER` does not actually escalate. This is rare because Supabase functions are typically owned by a privileged role, but worth checking the owner column shown above.
+
+In every other case the lint is reporting a real privilege escalation: any signed-up user — including throwaway accounts created via open signup — can run code that reads or writes data they otherwise could not.

--- a/lints/0001_unindexed_foreign_keys.sql
+++ b/lints/0001_unindexed_foreign_keys.sql
@@ -64,7 +64,7 @@ from
 where
     idx.index_ is null
     and fk.schema_name not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude tables owned by extensions
 order by

--- a/lints/0003_auth_rls_initplan.sql
+++ b/lints/0003_auth_rls_initplan.sql
@@ -54,7 +54,7 @@ where
     is_rls_active
     -- NOTE: does not include realtime in support of monitoring policies on realtime.messages
     and schema_name not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and (
         -- Example: auth.uid()

--- a/lints/0004_no_primary_key.sql
+++ b/lints/0004_no_primary_key.sql
@@ -35,7 +35,7 @@ from
 where
     pgc.relkind = 'r' -- regular tables
     and pgns.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude tables owned by extensions
 group by

--- a/lints/0005_unused_index.sql
+++ b/lints/0005_unused_index.sql
@@ -39,5 +39,5 @@ where
     and not pi.indisprimary
     and dep.objid is null -- exclude tables owned by extensions
     and psui.schemaname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     );

--- a/lints/0006_multiple_permissive_policies.sql
+++ b/lints/0006_multiple_permissive_policies.sql
@@ -58,7 +58,7 @@ where
     c.relkind = 'r' -- regular tables
     and p.polpermissive -- policy is permissive
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and r.rolname not like 'pg_%'
     and r.rolname not like 'supabase%admin'

--- a/lints/0007_policy_exists_rls_disabled.sql
+++ b/lints/0007_policy_exists_rls_disabled.sql
@@ -36,7 +36,7 @@ from
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     -- RLS is disabled
     and not c.relrowsecurity

--- a/lints/0008_rls_enabled_no_policy.sql
+++ b/lints/0008_rls_enabled_no_policy.sql
@@ -35,7 +35,7 @@ from
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     -- RLS is enabled
     and c.relrowsecurity

--- a/lints/0009_duplicate_index.sql
+++ b/lints/0009_duplicate_index.sql
@@ -43,7 +43,7 @@ from
 where
     c.relkind in ('r', 'm') -- tables and materialized views
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude tables owned by extensions
 group by

--- a/lints/0010_security_definer_view.sql
+++ b/lints/0010_security_definer_view.sql
@@ -39,7 +39,7 @@ where
     and substring(pg_catalog.version() from 'PostgreSQL ([0-9]+)') >= '15' -- security invoker was added in pg15
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude views owned by extensions
     and not (

--- a/lints/0011_function_search_path_mutable.sql
+++ b/lints/0011_function_search_path_mutable.sql
@@ -33,7 +33,7 @@ from
         and dep.deptype = 'e'
 where
     n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude functions owned by extensions
     -- Search path not set

--- a/lints/0013_rls_disabled_in_public.sql
+++ b/lints/0013_rls_disabled_in_public.sql
@@ -37,5 +37,5 @@ where
     )
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     );

--- a/lints/0015_rls_references_user_metadata.sql
+++ b/lints/0015_rls_references_user_metadata.sql
@@ -42,7 +42,7 @@ from
     policies
 where
     schema_name not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and (
         -- Example: auth.jwt() -> 'user_metadata'

--- a/lints/0016_materialized_view_in_api.sql
+++ b/lints/0016_materialized_view_in_api.sql
@@ -38,6 +38,6 @@ where
     )
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null;

--- a/lints/0017_foreign_table_in_api.sql
+++ b/lints/0017_foreign_table_in_api.sql
@@ -38,6 +38,6 @@ where
     )
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null;

--- a/lints/0023_sensitive_columns_exposed.sql
+++ b/lints/0023_sensitive_columns_exposed.sql
@@ -50,7 +50,7 @@ exposed_tables as (
         )
         and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
         and n.nspname not in (
-            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )
         -- Only flag tables without RLS enabled
         and not c.relrowsecurity

--- a/lints/0024_rls_policy_always_true.sql
+++ b/lints/0024_rls_policy_always_true.sql
@@ -36,7 +36,7 @@ with policies as (
     where
         pc.relkind = 'r' -- regular tables
         and nsp.nspname not in (
-            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )
 ),
 permissive_patterns as (

--- a/lints/0027_pg_graphql_authenticated_table_exposed.sql
+++ b/lints/0027_pg_graphql_authenticated_table_exposed.sql
@@ -1,22 +1,26 @@
-create view lint."0026_pg_graphql_anon_table_exposed" as
+create view lint."0027_pg_graphql_authenticated_table_exposed" as
 
 -- Detects tables, views, materialized views, and foreign tables whose
--- schema is visible to the `anon` role through pg_graphql introspection.
--- pg_graphql introspection reflects the calling role's Postgres
--- privileges: if `anon` can SELECT an object, its name, columns, and
--- relationships are visible via /graphql/v1 to anyone with the public
--- anon key, even when RLS is enabled.
+-- schema is visible to the `authenticated` role through pg_graphql
+-- introspection. pg_graphql introspection reflects the calling role's
+-- Postgres privileges: if `authenticated` can SELECT an object, its
+-- name, columns, and relationships are visible via /graphql/v1 to any
+-- signed-up user, even when RLS is enabled.
 --
--- See lint 0027 for the equivalent check against the `authenticated`
--- role. In default Supabase projects the two roles share the same
--- default-privilege grants, so revoking from `anon` alone often leaves
--- the introspection response served to any signed-up user unchanged.
+-- See lint 0026 for the equivalent check against the `anon` role. In
+-- default Supabase projects the two roles share the same
+-- default-privilege grants — `ALTER DEFAULT PRIVILEGES FOR ROLE
+-- supabase_admin ... TO anon, authenticated, service_role` — so an
+-- object readable by `anon` is typically also readable by
+-- `authenticated`. If signup is open or auto-confirm, "authenticated"
+-- is in practice anyone with a throwaway email rather than a
+-- meaningfully smaller audience.
 --
 -- The privilege check uses has_column_privilege rather than
 -- has_table_privilege so that column-level grants such as
--- `GRANT SELECT (some_col) ON t TO anon` are also caught: pg_graphql
--- exposes a relation in introspection if any column is selectable to
--- the calling role (`load_sql_context.sql:327`,
+-- `GRANT SELECT (some_col) ON t TO authenticated` are also caught:
+-- pg_graphql exposes a relation in introspection if any column is
+-- selectable to the calling role (`load_sql_context.sql:327`,
 -- `is_column_selectable`).
 --
 -- The relkind set ('r','v','m','f') matches pg_graphql's own filter in
@@ -52,7 +56,7 @@ exposed_objects as (
             where a.attrelid = c.oid
                 and a.attnum > 0
                 and not a.attisdropped
-                and pg_catalog.has_column_privilege('anon', c.oid, a.attnum, 'SELECT')
+                and pg_catalog.has_column_privilege('authenticated', c.oid, a.attnum, 'SELECT')
         )
         and exists (select 1 from graphql_installed)
         and n.nspname not in (
@@ -60,26 +64,26 @@ exposed_objects as (
         )
 )
 select
-    'pg_graphql_anon_table_exposed' as name,
-    'pg_graphql Anon Role Exposes Objects in Introspection' as title,
+    'pg_graphql_authenticated_table_exposed' as name,
+    'pg_graphql Authenticated Role Exposes Objects in Introspection' as title,
     'WARN' as level,
     'EXTERNAL' as facing,
     array['SECURITY'] as categories,
-    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the public `/graphql/v1` introspection endpoint. When `pg_graphql` is installed, any object the `anon` role has `SELECT` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. See lint 0027 for the equivalent check against the `authenticated` role; in default Supabase projects revoking from `anon` alone is not sufficient.' as description,
+    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the `/graphql/v1` introspection endpoint to any signed-up user. When `pg_graphql` is installed, any object the `authenticated` role has `SELECT` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. In default Supabase projects `authenticated` is anyone with a valid JWT, which under open or auto-confirm signup is anyone with a throwaway email. See lint 0026 for the equivalent check against `anon`.' as description,
     format(
-        'Extension `pg_graphql` is installed and the `anon` role has `SELECT` on %s `%s.%s`. Its name, columns, and relationships are visible via the public `/graphql/v1` introspection endpoint.',
+        'Extension `pg_graphql` is installed and the `authenticated` role has `SELECT` on %s `%s.%s`. Its name, columns, and relationships are visible via the `/graphql/v1` introspection endpoint to any signed-up user.',
         object_type,
         schema_name,
         object_name
     ) as detail,
-    'https://supabase.com/docs/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed' as remediation,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0027_pg_graphql_authenticated_table_exposed' as remediation,
     jsonb_build_object(
         'schema', schema_name,
         'name', object_name,
         'type', object_type
     ) as metadata,
     format(
-        'pg_graphql_anon_table_exposed_%s_%s',
+        'pg_graphql_authenticated_table_exposed_%s_%s',
         schema_name,
         object_name
     ) as cache_key

--- a/lints/0028_anon_security_definer_function_executable.sql
+++ b/lints/0028_anon_security_definer_function_executable.sql
@@ -1,0 +1,71 @@
+create view lint."0028_anon_security_definer_function_executable" as
+
+-- Detects SECURITY DEFINER functions that the `anon` role has EXECUTE
+-- on. SECURITY DEFINER functions run with the privileges of their
+-- owner (typically a superuser-equivalent role) rather than the
+-- caller, so they bypass RLS on every table they read or write.
+-- Granting EXECUTE to `anon` therefore lets any holder of the public
+-- anon key invoke a privileged operation through PostgREST
+-- `/rest/v1/rpc/<name>`, and through `/graphql/v1` Query/Mutation
+-- fields when pg_graphql is installed and the return type is
+-- supported.
+--
+-- See lint 0029 for the equivalent check against the `authenticated`
+-- role. Together with 0026/0027 they cover the four direct
+-- exposure paths: anon-vs-authenticated × table-vs-function.
+--
+-- This lint deliberately does not gate on pg_graphql being installed:
+-- PostgREST exposes `/rest/v1/rpc` independently and is the more
+-- commonly deployed surface for the same risk.
+select
+    'anon_security_definer_function_executable' as name,
+    'SECURITY DEFINER Function Executable by Anon' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects SECURITY DEFINER functions that the `anon` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to `anon` lets any holder of the public anon key invoke a privileged operation via PostgREST `/rest/v1/rpc/<name>` (and via `/graphql/v1` when pg_graphql is installed and the function''s return type is supported). See lint 0029 for the equivalent check against the `authenticated` role.' as description,
+    format(
+        'SECURITY DEFINER function `%s.%s(%s)` is executable by the `anon` role. It runs with the privileges of its owner and bypasses RLS, so any unauthenticated caller can invoke it via `/rest/v1/rpc/%s`.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'anon_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args;

--- a/lints/0028_anon_security_definer_function_executable.sql
+++ b/lints/0028_anon_security_definer_function_executable.sql
@@ -61,6 +61,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )

--- a/lints/0029_authenticated_security_definer_function_executable.sql
+++ b/lints/0029_authenticated_security_definer_function_executable.sql
@@ -1,0 +1,72 @@
+create view lint."0029_authenticated_security_definer_function_executable" as
+
+-- Detects SECURITY DEFINER functions that the `authenticated` role
+-- has EXECUTE on. SECURITY DEFINER functions run with the privileges
+-- of their owner (typically a superuser-equivalent role) rather than
+-- the caller, so they bypass RLS on every table they read or write.
+-- Granting EXECUTE to `authenticated` therefore lets any signed-up
+-- user invoke a privileged operation through PostgREST
+-- `/rest/v1/rpc/<name>`, and through `/graphql/v1` Query/Mutation
+-- fields when pg_graphql is installed and the return type is
+-- supported. Under open or auto-confirm signup, "authenticated" is in
+-- practice anyone with a throwaway email.
+--
+-- See lint 0028 for the equivalent check against the `anon` role.
+-- Together with 0026/0027 they cover the four direct exposure paths:
+-- anon-vs-authenticated × table-vs-function.
+--
+-- This lint deliberately does not gate on pg_graphql being installed:
+-- PostgREST exposes `/rest/v1/rpc` independently and is the more
+-- commonly deployed surface for the same risk.
+select
+    'authenticated_security_definer_function_executable' as name,
+    'SECURITY DEFINER Function Executable by Authenticated' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects SECURITY DEFINER functions that the `authenticated` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to `authenticated` lets any signed-up user invoke a privileged operation via PostgREST `/rest/v1/rpc/<name>` (and via `/graphql/v1` when pg_graphql is installed and the function''s return type is supported). Under open or auto-confirm signup `authenticated` is anyone with a throwaway email. See lint 0028 for the equivalent check against the `anon` role.' as description,
+    format(
+        'SECURITY DEFINER function `%s.%s(%s)` is executable by the `authenticated` role. It runs with the privileges of its owner and bypasses RLS, so any signed-up user can invoke it via `/rest/v1/rpc/%s`.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'authenticated_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args;

--- a/lints/0029_authenticated_security_definer_function_executable.sql
+++ b/lints/0029_authenticated_security_definer_function_executable.sql
@@ -62,6 +62,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )

--- a/splinter.sql
+++ b/splinter.sql
@@ -65,7 +65,7 @@ from
 where
     idx.index_ is null
     and fk.schema_name not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude tables owned by extensions
 order by
@@ -217,7 +217,7 @@ where
     is_rls_active
     -- NOTE: does not include realtime in support of monitoring policies on realtime.messages
     and schema_name not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and (
         -- Example: auth.uid()
@@ -299,7 +299,7 @@ from
 where
     pgc.relkind = 'r' -- regular tables
     and pgns.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude tables owned by extensions
 group by
@@ -349,7 +349,7 @@ where
     and not pi.indisprimary
     and dep.objid is null -- exclude tables owned by extensions
     and psui.schemaname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     ))
 union all
 (
@@ -411,7 +411,7 @@ where
     c.relkind = 'r' -- regular tables
     and p.polpermissive -- policy is permissive
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and r.rolname not like 'pg_%'
     and r.rolname not like 'supabase%admin'
@@ -462,7 +462,7 @@ from
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     -- RLS is disabled
     and not c.relrowsecurity
@@ -507,7 +507,7 @@ from
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     -- RLS is enabled
     and c.relrowsecurity
@@ -561,7 +561,7 @@ from
 where
     c.relkind in ('r', 'm') -- tables and materialized views
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude tables owned by extensions
 group by
@@ -612,7 +612,7 @@ where
     and substring(pg_catalog.version() from 'PostgreSQL ([0-9]+)') >= '15' -- security invoker was added in pg15
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude views owned by extensions
     and not (
@@ -659,7 +659,7 @@ from
         and dep.deptype = 'e'
 where
     n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null -- exclude functions owned by extensions
     -- Search path not set
@@ -707,7 +707,7 @@ where
     )
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     ))
 union all
 (
@@ -787,7 +787,7 @@ from
     policies
 where
     schema_name not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and (
         -- Example: auth.jwt() -> 'user_metadata'
@@ -838,7 +838,7 @@ where
     )
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null)
 union all
@@ -881,7 +881,7 @@ where
     )
     and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
     and n.nspname not in (
-        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
     and dep.objid is null)
 union all
@@ -1200,7 +1200,7 @@ exposed_tables as (
         )
         and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
         and n.nspname not in (
-            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )
         -- Only flag tables without RLS enabled
         and not c.relrowsecurity
@@ -1294,7 +1294,7 @@ with policies as (
     where
         pc.relkind = 'r' -- regular tables
         and nsp.nspname not in (
-            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )
 ),
 permissive_patterns as (
@@ -1484,11 +1484,29 @@ order by
     bucket_id)
 union all
 (
--- Detects tables, views, and materialized views whose schema is visible
--- through pg_graphql introspection. pg_graphql introspection reflects the
--- calling role's Postgres privileges: if `anon` can SELECT an object, its
--- name, columns, and relationships are visible to anyone with the public
--- anon key via /graphql/v1, even when RLS is enabled.
+-- Detects tables, views, materialized views, and foreign tables whose
+-- schema is visible to the `anon` role through pg_graphql introspection.
+-- pg_graphql introspection reflects the calling role's Postgres
+-- privileges: if `anon` can SELECT an object, its name, columns, and
+-- relationships are visible via /graphql/v1 to anyone with the public
+-- anon key, even when RLS is enabled.
+--
+-- See lint 0027 for the equivalent check against the `authenticated`
+-- role. In default Supabase projects the two roles share the same
+-- default-privilege grants, so revoking from `anon` alone often leaves
+-- the introspection response served to any signed-up user unchanged.
+--
+-- The privilege check uses has_column_privilege rather than
+-- has_table_privilege so that column-level grants such as
+-- `GRANT SELECT (some_col) ON t TO anon` are also caught: pg_graphql
+-- exposes a relation in introspection if any column is selectable to
+-- the calling role (`load_sql_context.sql:327`,
+-- `is_column_selectable`).
+--
+-- The relkind set ('r','v','m','f') matches pg_graphql's own filter in
+-- load_sql_context.sql. Partitioned table roots ('p') are excluded
+-- because pg_graphql does not expose them their leaf partitions ('r')
+-- are still picked up.
 with graphql_installed as (
     select 1 as installed
     from pg_catalog.pg_extension
@@ -1501,20 +1519,28 @@ exposed_objects as (
         c.relkind as object_relkind,
         case c.relkind
             when 'r' then 'table'
-            when 'p' then 'table'
             when 'v' then 'view'
             when 'm' then 'materialized view'
+            when 'f' then 'foreign table'
         end as object_type
     from
         pg_catalog.pg_class c
         join pg_catalog.pg_namespace n
             on c.relnamespace = n.oid
     where
-        c.relkind in ('r', 'p', 'v', 'm') -- tables, partitioned tables, views, materialized views
-        and pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        c.relkind in ('r', 'v', 'm', 'f') -- tables, views, materialized views, foreign tables matches pg_graphql
+        and exists (
+            -- Any selectable column (table-level or column-level grant)
+            select 1
+            from pg_catalog.pg_attribute a
+            where a.attrelid = c.oid
+                and a.attnum > 0
+                and not a.attisdropped
+                and pg_catalog.has_column_privilege('anon', c.oid, a.attnum, 'SELECT')
+        )
         and exists (select 1 from graphql_installed)
         and n.nspname not in (
-            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )
 )
 select
@@ -1523,7 +1549,7 @@ select
     'WARN' as level,
     'EXTERNAL' as facing,
     array['SECURITY'] as categories,
-    'Detects tables and views whose schema is visible via the public `/graphql/v1` introspection endpoint. When `pg_graphql` is installed, any table, view, or materialized view the `anon` role has `SELECT` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. Both forms of introspection are intentional behavior this lint surfaces the objects that are currently public so you can confirm each one is meant to be discoverable without authentication.' as description,
+    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the public `/graphql/v1` introspection endpoint. When `pg_graphql` is installed, any object the `anon` role has `SELECT` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. See lint 0027 for the equivalent check against the `authenticated` role in default Supabase projects revoking from `anon` alone is not sufficient.' as description,
     format(
         'Extension `pg_graphql` is installed and the `anon` role has `SELECT` on %s `%s.%s`. Its name, columns, and relationships are visible via the public `/graphql/v1` introspection endpoint.',
         object_type,
@@ -1546,3 +1572,240 @@ from
 order by
     schema_name,
     object_name)
+union all
+(
+-- Detects tables, views, materialized views, and foreign tables whose
+-- schema is visible to the `authenticated` role through pg_graphql
+-- introspection. pg_graphql introspection reflects the calling role's
+-- Postgres privileges: if `authenticated` can SELECT an object, its
+-- name, columns, and relationships are visible via /graphql/v1 to any
+-- signed-up user, even when RLS is enabled.
+--
+-- See lint 0026 for the equivalent check against the `anon` role. In
+-- default Supabase projects the two roles share the same
+-- default-privilege grants — `ALTER DEFAULT PRIVILEGES FOR ROLE
+-- supabase_admin ... TO anon, authenticated, service_role` — so an
+-- object readable by `anon` is typically also readable by
+-- `authenticated`. If signup is open or auto-confirm, "authenticated"
+-- is in practice anyone with a throwaway email rather than a
+-- meaningfully smaller audience.
+--
+-- The privilege check uses has_column_privilege rather than
+-- has_table_privilege so that column-level grants such as
+-- `GRANT SELECT (some_col) ON t TO authenticated` are also caught:
+-- pg_graphql exposes a relation in introspection if any column is
+-- selectable to the calling role (`load_sql_context.sql:327`,
+-- `is_column_selectable`).
+--
+-- The relkind set ('r','v','m','f') matches pg_graphql's own filter in
+-- load_sql_context.sql. Partitioned table roots ('p') are excluded
+-- because pg_graphql does not expose them their leaf partitions ('r')
+-- are still picked up.
+with graphql_installed as (
+    select 1 as installed
+    from pg_catalog.pg_extension
+    where extname = 'pg_graphql'
+),
+exposed_objects as (
+    select
+        n.nspname as schema_name,
+        c.relname as object_name,
+        c.relkind as object_relkind,
+        case c.relkind
+            when 'r' then 'table'
+            when 'v' then 'view'
+            when 'm' then 'materialized view'
+            when 'f' then 'foreign table'
+        end as object_type
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind in ('r', 'v', 'm', 'f') -- tables, views, materialized views, foreign tables matches pg_graphql
+        and exists (
+            -- Any selectable column (table-level or column-level grant)
+            select 1
+            from pg_catalog.pg_attribute a
+            where a.attrelid = c.oid
+                and a.attnum > 0
+                and not a.attisdropped
+                and pg_catalog.has_column_privilege('authenticated', c.oid, a.attnum, 'SELECT')
+        )
+        and exists (select 1 from graphql_installed)
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+)
+select
+    'pg_graphql_authenticated_table_exposed' as name,
+    'pg_graphql Authenticated Role Exposes Objects in Introspection' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the `/graphql/v1` introspection endpoint to any signed-up user. When `pg_graphql` is installed, any object the `authenticated` role has `SELECT` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. In default Supabase projects `authenticated` is anyone with a valid JWT, which under open or auto-confirm signup is anyone with a throwaway email. See lint 0026 for the equivalent check against `anon`.' as description,
+    format(
+        'Extension `pg_graphql` is installed and the `authenticated` role has `SELECT` on %s `%s.%s`. Its name, columns, and relationships are visible via the `/graphql/v1` introspection endpoint to any signed-up user.',
+        object_type,
+        schema_name,
+        object_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0027_pg_graphql_authenticated_table_exposed' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', object_name,
+        'type', object_type
+    ) as metadata,
+    format(
+        'pg_graphql_authenticated_table_exposed_%s_%s',
+        schema_name,
+        object_name
+    ) as cache_key
+from
+    exposed_objects
+order by
+    schema_name,
+    object_name)
+union all
+(
+-- Detects SECURITY DEFINER functions that the `anon` role has EXECUTE
+-- on. SECURITY DEFINER functions run with the privileges of their
+-- owner (typically a superuser-equivalent role) rather than the
+-- caller, so they bypass RLS on every table they read or write.
+-- Granting EXECUTE to `anon` therefore lets any holder of the public
+-- anon key invoke a privileged operation through PostgREST
+-- `/rest/v1/rpc/<name>`, and through `/graphql/v1` Query/Mutation
+-- fields when pg_graphql is installed and the return type is
+-- supported.
+--
+-- See lint 0029 for the equivalent check against the `authenticated`
+-- role. Together with 0026/0027 they cover the four direct
+-- exposure paths: anon-vs-authenticated × table-vs-function.
+--
+-- This lint deliberately does not gate on pg_graphql being installed:
+-- PostgREST exposes `/rest/v1/rpc` independently and is the more
+-- commonly deployed surface for the same risk.
+select
+    'anon_security_definer_function_executable' as name,
+    'SECURITY DEFINER Function Executable by Anon' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects SECURITY DEFINER functions that the `anon` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to `anon` lets any holder of the public anon key invoke a privileged operation via PostgREST `/rest/v1/rpc/<name>` (and via `/graphql/v1` when pg_graphql is installed and the function''s return type is supported). See lint 0029 for the equivalent check against the `authenticated` role.' as description,
+    format(
+        'SECURITY DEFINER function `%s.%s(%s)` is executable by the `anon` role. It runs with the privileges of its owner and bypasses RLS, so any unauthenticated caller can invoke it via `/rest/v1/rpc/%s`.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'anon_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args)
+union all
+(
+-- Detects SECURITY DEFINER functions that the `authenticated` role
+-- has EXECUTE on. SECURITY DEFINER functions run with the privileges
+-- of their owner (typically a superuser-equivalent role) rather than
+-- the caller, so they bypass RLS on every table they read or write.
+-- Granting EXECUTE to `authenticated` therefore lets any signed-up
+-- user invoke a privileged operation through PostgREST
+-- `/rest/v1/rpc/<name>`, and through `/graphql/v1` Query/Mutation
+-- fields when pg_graphql is installed and the return type is
+-- supported. Under open or auto-confirm signup, "authenticated" is in
+-- practice anyone with a throwaway email.
+--
+-- See lint 0028 for the equivalent check against the `anon` role.
+-- Together with 0026/0027 they cover the four direct exposure paths:
+-- anon-vs-authenticated × table-vs-function.
+--
+-- This lint deliberately does not gate on pg_graphql being installed:
+-- PostgREST exposes `/rest/v1/rpc` independently and is the more
+-- commonly deployed surface for the same risk.
+select
+    'authenticated_security_definer_function_executable' as name,
+    'SECURITY DEFINER Function Executable by Authenticated' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects SECURITY DEFINER functions that the `authenticated` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to `authenticated` lets any signed-up user invoke a privileged operation via PostgREST `/rest/v1/rpc/<name>` (and via `/graphql/v1` when pg_graphql is installed and the function''s return type is supported). Under open or auto-confirm signup `authenticated` is anyone with a throwaway email. See lint 0028 for the equivalent check against the `anon` role.' as description,
+    format(
+        'SECURITY DEFINER function `%s.%s(%s)` is executable by the `authenticated` role. It runs with the privileges of its owner and bypasses RLS, so any signed-up user can invoke it via `/rest/v1/rpc/%s`.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'authenticated_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args)

--- a/splinter.sql
+++ b/splinter.sql
@@ -1729,6 +1729,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )
@@ -1801,6 +1802,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )

--- a/test/expected/0026_pg_graphql_anon_table_exposed.out
+++ b/test/expected/0026_pg_graphql_anon_table_exposed.out
@@ -8,8 +8,9 @@ begin;
 
   savepoint a;
   ----------------------------------------
-  -- NEGATIVE EXAMPLE: anon has SELECT on a table but pg_graphql is NOT installed.
-  -- Without the extension there is no /graphql/v1 endpoint, so introspection is not active.
+  -- NEGATIVE EXAMPLE: anon has SELECT on a table but pg_graphql is NOT
+  -- installed. Without the extension there is no /graphql/v1 endpoint,
+  -- so the lint must not fire.
   ----------------------------------------
   create table public.products(id int primary key, name text);
   -- Default privileges from fixtures grant SELECT on new public tables to PUBLIC,
@@ -20,11 +21,14 @@ begin;
 (0 rows)
 
   rollback to savepoint a;
-  ----------------------------------------
-  -- POSITIVE EXAMPLE: pg_graphql IS installed and `anon` has SELECT on a table AND a view.
-  -- Both objects are visible via /graphql/v1 introspection.
-  ----------------------------------------
+  -- All positive cases below require pg_graphql to be installed.
   create extension pg_graphql;
+  savepoint case_table_view_matview;
+  ----------------------------------------
+  -- POSITIVE: `anon` has SELECT (via the fixture's PUBLIC default
+  -- grant) on a table, a view, and a materialized view. All three
+  -- relkinds covered by the lint should appear, ordered by object name.
+  ----------------------------------------
   create table public.internal_api_keys(
     id int primary key,
     service text,
@@ -32,27 +36,112 @@ begin;
   );
   create view public.api_key_summary as
     select id, service from public.internal_api_keys;
-  -- Both the table and the view should appear, ordered by object name.
+  create materialized view public.api_key_archive as
+    select id, service from public.internal_api_keys;
   select
     name,
     metadata->>'type' as object_type,
     cache_key
   from lint."0026_pg_graphql_anon_table_exposed";
-             name              | object_type |                       cache_key                        
--------------------------------+-------------+--------------------------------------------------------
- pg_graphql_anon_table_exposed | view        | pg_graphql_anon_table_exposed_public_api_key_summary
- pg_graphql_anon_table_exposed | table       | pg_graphql_anon_table_exposed_public_internal_api_keys
-(2 rows)
+             name              |    object_type    |                       cache_key                        
+-------------------------------+-------------------+--------------------------------------------------------
+ pg_graphql_anon_table_exposed | materialized view | pg_graphql_anon_table_exposed_public_api_key_archive
+ pg_graphql_anon_table_exposed | view              | pg_graphql_anon_table_exposed_public_api_key_summary
+ pg_graphql_anon_table_exposed | table             | pg_graphql_anon_table_exposed_public_internal_api_keys
+(3 rows)
 
   ----------------------------------------
-  -- RESOLUTION: revoke from anon and from public on both objects.
-  -- After revoking, has_table_privilege('anon', ...) is false and the lint clears.
+  -- RESOLUTION: revoke from anon (and PUBLIC, which anon rides on by
+  -- default). After revoking, has_table_privilege('anon', ...) is false
+  -- and the lint clears.
   ----------------------------------------
   revoke all on public.internal_api_keys from anon, public;
-  revoke all on public.api_key_summary from anon, public;
+  revoke all on public.api_key_summary   from anon, public;
+  revoke all on public.api_key_archive   from anon, public;
   select * from lint."0026_pg_graphql_anon_table_exposed";
  name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
 ------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
 (0 rows)
 
+  rollback to savepoint case_table_view_matview;
+  savepoint case_foreign;
+  ----------------------------------------
+  -- POSITIVE (foreign table): pg_graphql exposes relkind='f' relations,
+  -- so the lint must too. The fixture's default grant to PUBLIC also
+  -- applies to foreign tables.
+  ----------------------------------------
+  create extension postgres_fdw schema extensions;
+  create server fdw_test foreign data wrapper postgres_fdw
+    options (host 'localhost', dbname 'postgres');
+  create foreign table public.foreign_secrets(
+    id int,
+    secret text
+  ) server fdw_test;
+  select
+    name,
+    metadata->>'type' as object_type,
+    cache_key
+  from lint."0026_pg_graphql_anon_table_exposed";
+             name              |  object_type  |                      cache_key                       
+-------------------------------+---------------+------------------------------------------------------
+ pg_graphql_anon_table_exposed | foreign table | pg_graphql_anon_table_exposed_public_foreign_secrets
+(1 row)
+
+  rollback to savepoint case_foreign;
+  savepoint case_partitioned;
+  ----------------------------------------
+  -- MIXED: a partitioned table root (relkind='p') and a leaf partition
+  -- (relkind='r'). pg_graphql exposes only the leaves, so only the leaf
+  -- should appear; the root must NOT fire under the new filter.
+  ----------------------------------------
+  create table public.parted(id int, region text) partition by list(region);
+  create table public.parted_us partition of public.parted for values in ('us');
+  select
+    name,
+    metadata->>'type' as object_type,
+    cache_key
+  from lint."0026_pg_graphql_anon_table_exposed";
+             name              | object_type |                   cache_key                    
+-------------------------------+-------------+------------------------------------------------
+ pg_graphql_anon_table_exposed | table       | pg_graphql_anon_table_exposed_public_parted_us
+(1 row)
+
+  rollback to savepoint case_partitioned;
+  savepoint case_anon_revoked;
+  ----------------------------------------
+  -- NEGATIVE: pg_graphql installed and `authenticated` has SELECT, but
+  -- `anon` does NOT. Lint 0026 must not fire (this is precisely the
+  -- "operator followed the original 0026 doc verbatim" state — see
+  -- lint 0027 for the equivalent authenticated-side check).
+  ----------------------------------------
+  create table public.auth_only_tbl(id int primary key);
+  revoke select on public.auth_only_tbl from public;
+  grant select on public.auth_only_tbl to authenticated;
+  select * from lint."0026_pg_graphql_anon_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_anon_revoked;
+  savepoint case_column_only_grant;
+  ----------------------------------------
+  -- POSITIVE (column-level grant only): `anon` has SELECT on a single
+  -- column, no table-level SELECT, and no PUBLIC grant. pg_graphql
+  -- exposes any relation with at least one selectable column, so the
+  -- lint must too. has_table_privilege would have missed this case.
+  ----------------------------------------
+  create table public.col_grant_only(id int primary key, secret text);
+  revoke select on public.col_grant_only from public, anon, authenticated;
+  grant select (id) on public.col_grant_only to anon;
+  select
+    name,
+    metadata->>'type' as object_type,
+    cache_key
+  from lint."0026_pg_graphql_anon_table_exposed";
+             name              | object_type |                      cache_key                      
+-------------------------------+-------------+-----------------------------------------------------
+ pg_graphql_anon_table_exposed | table       | pg_graphql_anon_table_exposed_public_col_grant_only
+(1 row)
+
+  rollback to savepoint case_column_only_grant;
 rollback;

--- a/test/expected/0027_pg_graphql_authenticated_table_exposed.out
+++ b/test/expected/0027_pg_graphql_authenticated_table_exposed.out
@@ -1,0 +1,151 @@
+begin;
+  set local search_path = '';
+  -- BASELINE: pg_graphql not installed, no rows
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  savepoint a;
+  ----------------------------------------
+  -- NEGATIVE EXAMPLE: authenticated has SELECT on a table but
+  -- pg_graphql is NOT installed. Without the extension there is no
+  -- /graphql/v1 endpoint, so the lint must not fire.
+  ----------------------------------------
+  create table public.products(id int primary key, name text);
+  -- Default privileges from fixtures grant SELECT on new public tables to PUBLIC,
+  -- so `authenticated` already has SELECT here. The lint must still report 0 rows.
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint a;
+  -- All positive cases below require pg_graphql to be installed.
+  create extension pg_graphql;
+  savepoint case_table_view_matview;
+  ----------------------------------------
+  -- POSITIVE: `authenticated` has SELECT (via the fixture's PUBLIC
+  -- default grant) on a table, a view, and a materialized view. All
+  -- three relkinds covered by the lint should appear, ordered by
+  -- object name.
+  ----------------------------------------
+  create table public.internal_api_keys(
+    id int primary key,
+    service text,
+    key_hash text
+  );
+  create view public.api_key_summary as
+    select id, service from public.internal_api_keys;
+  create materialized view public.api_key_archive as
+    select id, service from public.internal_api_keys;
+  select
+    name,
+    metadata->>'type' as object_type,
+    cache_key
+  from lint."0027_pg_graphql_authenticated_table_exposed";
+                  name                  |    object_type    |                            cache_key                            
+----------------------------------------+-------------------+-----------------------------------------------------------------
+ pg_graphql_authenticated_table_exposed | materialized view | pg_graphql_authenticated_table_exposed_public_api_key_archive
+ pg_graphql_authenticated_table_exposed | view              | pg_graphql_authenticated_table_exposed_public_api_key_summary
+ pg_graphql_authenticated_table_exposed | table             | pg_graphql_authenticated_table_exposed_public_internal_api_keys
+(3 rows)
+
+  ----------------------------------------
+  -- RESOLUTION: revoke from authenticated (and PUBLIC, which
+  -- authenticated rides on by default). After revoking,
+  -- has_table_privilege('authenticated', ...) is false and the lint
+  -- clears.
+  ----------------------------------------
+  revoke all on public.internal_api_keys from authenticated, public;
+  revoke all on public.api_key_summary   from authenticated, public;
+  revoke all on public.api_key_archive   from authenticated, public;
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_table_view_matview;
+  savepoint case_foreign;
+  ----------------------------------------
+  -- POSITIVE (foreign table): pg_graphql exposes relkind='f' relations,
+  -- so the lint must too. The fixture's default grant to PUBLIC also
+  -- applies to foreign tables.
+  ----------------------------------------
+  create extension postgres_fdw schema extensions;
+  create server fdw_test foreign data wrapper postgres_fdw
+    options (host 'localhost', dbname 'postgres');
+  create foreign table public.foreign_secrets(
+    id int,
+    secret text
+  ) server fdw_test;
+  select
+    name,
+    metadata->>'type' as object_type,
+    cache_key
+  from lint."0027_pg_graphql_authenticated_table_exposed";
+                  name                  |  object_type  |                           cache_key                           
+----------------------------------------+---------------+---------------------------------------------------------------
+ pg_graphql_authenticated_table_exposed | foreign table | pg_graphql_authenticated_table_exposed_public_foreign_secrets
+(1 row)
+
+  rollback to savepoint case_foreign;
+  savepoint case_partitioned;
+  ----------------------------------------
+  -- MIXED: a partitioned table root (relkind='p') and a leaf partition
+  -- (relkind='r'). pg_graphql exposes only the leaves, so only the leaf
+  -- should appear; the root must NOT fire under the new filter.
+  ----------------------------------------
+  create table public.parted(id int, region text) partition by list(region);
+  create table public.parted_us partition of public.parted for values in ('us');
+  select
+    name,
+    metadata->>'type' as object_type,
+    cache_key
+  from lint."0027_pg_graphql_authenticated_table_exposed";
+                  name                  | object_type |                        cache_key                        
+----------------------------------------+-------------+---------------------------------------------------------
+ pg_graphql_authenticated_table_exposed | table       | pg_graphql_authenticated_table_exposed_public_parted_us
+(1 row)
+
+  rollback to savepoint case_partitioned;
+  savepoint case_authenticated_revoked;
+  ----------------------------------------
+  -- NEGATIVE: pg_graphql installed and `anon` has SELECT, but
+  -- `authenticated` does NOT. Lint 0027 must not fire — this is the
+  -- mirror image of 0026's "revoke from anon, keep on authenticated"
+  -- state. It is unusual in practice but verifies the role check is
+  -- independent.
+  ----------------------------------------
+  create table public.anon_only_tbl(id int primary key);
+  revoke select on public.anon_only_tbl from public;
+  grant select on public.anon_only_tbl to anon;
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_authenticated_revoked;
+  savepoint case_column_only_grant;
+  ----------------------------------------
+  -- POSITIVE (column-level grant only): `authenticated` has SELECT on
+  -- a single column, no table-level SELECT, and no PUBLIC grant.
+  -- pg_graphql exposes any relation with at least one selectable
+  -- column, so the lint must too. has_table_privilege would have
+  -- missed this case.
+  ----------------------------------------
+  create table public.col_grant_only(id int primary key, secret text);
+  revoke select on public.col_grant_only from public, anon, authenticated;
+  grant select (id) on public.col_grant_only to authenticated;
+  select
+    name,
+    metadata->>'type' as object_type,
+    cache_key
+  from lint."0027_pg_graphql_authenticated_table_exposed";
+                  name                  | object_type |                          cache_key                           
+----------------------------------------+-------------+--------------------------------------------------------------
+ pg_graphql_authenticated_table_exposed | table       | pg_graphql_authenticated_table_exposed_public_col_grant_only
+(1 row)
+
+  rollback to savepoint case_column_only_grant;
+rollback;

--- a/test/expected/0028_anon_security_definer_function_executable.out
+++ b/test/expected/0028_anon_security_definer_function_executable.out
@@ -1,0 +1,123 @@
+begin;
+  set local search_path = '';
+  -- BASELINE: empty user-schema, no rows
+  select * from lint."0028_anon_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  savepoint a;
+  ----------------------------------------
+  -- NEGATIVE EXAMPLE: SECURITY INVOKER function, even with EXECUTE
+  -- granted to anon (via the Postgres default to PUBLIC), must not
+  -- fire. Invoker functions run as the caller and RLS still applies.
+  ----------------------------------------
+  create function public.invoker_func() returns int
+    language sql
+    security invoker
+    as $$ select 1 $$;
+  -- Postgres default grants EXECUTE on functions to PUBLIC, so anon
+  -- has EXECUTE here without an explicit grant.
+  select * from lint."0028_anon_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint a;
+  savepoint case_definer_default_grant;
+  ----------------------------------------
+  -- POSITIVE: SECURITY DEFINER function in public, EXECUTE granted to
+  -- anon via the Postgres default to PUBLIC. This is the most common
+  -- accidental exposure — the developer never granted EXECUTE
+  -- explicitly, the default did it.
+  ----------------------------------------
+  create function public.priv_op(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    metadata->>'security_definer' as security_definer,
+    cache_key
+  from lint."0028_anon_security_definer_function_executable";
+                   name                    | func_name |     func_args     | security_definer |                                 cache_key                                  
+-------------------------------------------+-----------+-------------------+------------------+----------------------------------------------------------------------------
+ anon_security_definer_function_executable | priv_op   | target_id integer | true             | anon_security_definer_function_executable_public_priv_op_target_id integer
+(1 row)
+
+  ----------------------------------------
+  -- RESOLUTION: revoke EXECUTE from anon and from PUBLIC. After
+  -- revoking, has_function_privilege('anon', ...) is false and the
+  -- lint clears.
+  ----------------------------------------
+  revoke execute on function public.priv_op(int) from anon, public;
+  select * from lint."0028_anon_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_definer_default_grant;
+  savepoint case_overloads;
+  ----------------------------------------
+  -- POSITIVE (overloads): two SECURITY DEFINER functions sharing a
+  -- name but with different argument lists. Each must produce a
+  -- separate finding with a unique cache_key based on the argument
+  -- signature.
+  ----------------------------------------
+  create function public.dispatch(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  create function public.dispatch(target_id int, label text) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    cache_key
+  from lint."0028_anon_security_definer_function_executable";
+                   name                    | func_name |           func_args           |                                        cache_key                                        
+-------------------------------------------+-----------+-------------------------------+-----------------------------------------------------------------------------------------
+ anon_security_definer_function_executable | dispatch  | target_id integer             | anon_security_definer_function_executable_public_dispatch_target_id integer
+ anon_security_definer_function_executable | dispatch  | target_id integer, label text | anon_security_definer_function_executable_public_dispatch_target_id integer, label text
+(2 rows)
+
+  rollback to savepoint case_overloads;
+  savepoint case_definer_revoked;
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function with EXECUTE explicitly
+  -- revoked from anon (and PUBLIC). Lint must not fire even though
+  -- `authenticated` may still have EXECUTE — that's lint 0029's job.
+  ----------------------------------------
+  create function public.admin_only() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  revoke execute on function public.admin_only() from public, anon;
+  select * from lint."0028_anon_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_definer_revoked;
+  savepoint case_system_schema;
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function in a system schema (auth)
+  -- must not fire even with EXECUTE to anon — system schemas are
+  -- excluded.
+  ----------------------------------------
+  create function auth.system_definer() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  select * from lint."0028_anon_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_system_schema;
+rollback;

--- a/test/expected/0029_authenticated_security_definer_function_executable.out
+++ b/test/expected/0029_authenticated_security_definer_function_executable.out
@@ -1,0 +1,119 @@
+NOTICE:  identifier "pg_regress/0029_authenticated_security_definer_function_executable" will be truncated to "pg_regress/0029_authenticated_security_definer_function_executa"
+begin;
+  set local search_path = '';
+  -- BASELINE: empty user-schema, no rows
+  select * from lint."0029_authenticated_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  savepoint a;
+  ----------------------------------------
+  -- NEGATIVE EXAMPLE: SECURITY INVOKER function, even with EXECUTE
+  -- granted to authenticated (via the Postgres default to PUBLIC),
+  -- must not fire. Invoker functions run as the caller and RLS still
+  -- applies.
+  ----------------------------------------
+  create function public.invoker_func() returns int
+    language sql
+    security invoker
+    as $$ select 1 $$;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint a;
+  savepoint case_definer_default_grant;
+  ----------------------------------------
+  -- POSITIVE: SECURITY DEFINER function in public, EXECUTE granted to
+  -- authenticated via the Postgres default to PUBLIC.
+  ----------------------------------------
+  create function public.priv_op(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    metadata->>'security_definer' as security_definer,
+    cache_key
+  from lint."0029_authenticated_security_definer_function_executable";
+                        name                        | func_name |     func_args     | security_definer |                                      cache_key                                      
+----------------------------------------------------+-----------+-------------------+------------------+-------------------------------------------------------------------------------------
+ authenticated_security_definer_function_executable | priv_op   | target_id integer | true             | authenticated_security_definer_function_executable_public_priv_op_target_id integer
+(1 row)
+
+  ----------------------------------------
+  -- RESOLUTION: revoke EXECUTE from authenticated and from PUBLIC.
+  ----------------------------------------
+  revoke execute on function public.priv_op(int) from authenticated, public;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_definer_default_grant;
+  savepoint case_overloads;
+  ----------------------------------------
+  -- POSITIVE (overloads): two SECURITY DEFINER functions sharing a
+  -- name but with different argument lists. Each must produce a
+  -- separate finding with a unique cache_key based on the argument
+  -- signature.
+  ----------------------------------------
+  create function public.dispatch(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  create function public.dispatch(target_id int, label text) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    cache_key
+  from lint."0029_authenticated_security_definer_function_executable";
+                        name                        | func_name |           func_args           |                                            cache_key                                             
+----------------------------------------------------+-----------+-------------------------------+--------------------------------------------------------------------------------------------------
+ authenticated_security_definer_function_executable | dispatch  | target_id integer             | authenticated_security_definer_function_executable_public_dispatch_target_id integer
+ authenticated_security_definer_function_executable | dispatch  | target_id integer, label text | authenticated_security_definer_function_executable_public_dispatch_target_id integer, label text
+(2 rows)
+
+  rollback to savepoint case_overloads;
+  savepoint case_definer_revoked;
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function with EXECUTE explicitly
+  -- revoked from authenticated (and PUBLIC). Lint must not fire even
+  -- though `anon` may still have EXECUTE — that's lint 0028's job.
+  ----------------------------------------
+  create function public.user_only() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  revoke execute on function public.user_only() from public, authenticated;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_definer_revoked;
+  savepoint case_system_schema;
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function in a system schema (auth)
+  -- must not fire even with EXECUTE to authenticated — system schemas
+  -- are excluded.
+  ----------------------------------------
+  create function auth.system_definer() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  rollback to savepoint case_system_schema;
+rollback;

--- a/test/expected/queries_are_unionable.out
+++ b/test/expected/queries_are_unionable.out
@@ -48,7 +48,13 @@ begin;
     union all
     select * from lint."0025_public_bucket_allows_listing"
     union all
-    select * from lint."0026_pg_graphql_anon_table_exposed";
+    select * from lint."0026_pg_graphql_anon_table_exposed"
+    union all
+    select * from lint."0027_pg_graphql_authenticated_table_exposed"
+    union all
+    select * from lint."0028_anon_security_definer_function_executable"
+    union all
+    select * from lint."0029_authenticated_security_definer_function_executable";
  name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
 ------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
 (0 rows)

--- a/test/sql/0027_pg_graphql_authenticated_table_exposed.sql
+++ b/test/sql/0027_pg_graphql_authenticated_table_exposed.sql
@@ -2,19 +2,19 @@ begin;
   set local search_path = '';
 
   -- BASELINE: pg_graphql not installed, no rows
-  select * from lint."0026_pg_graphql_anon_table_exposed";
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
 
   savepoint a;
 
   ----------------------------------------
-  -- NEGATIVE EXAMPLE: anon has SELECT on a table but pg_graphql is NOT
-  -- installed. Without the extension there is no /graphql/v1 endpoint,
-  -- so the lint must not fire.
+  -- NEGATIVE EXAMPLE: authenticated has SELECT on a table but
+  -- pg_graphql is NOT installed. Without the extension there is no
+  -- /graphql/v1 endpoint, so the lint must not fire.
   ----------------------------------------
   create table public.products(id int primary key, name text);
   -- Default privileges from fixtures grant SELECT on new public tables to PUBLIC,
-  -- so `anon` already has SELECT here. The lint must still report 0 rows.
-  select * from lint."0026_pg_graphql_anon_table_exposed";
+  -- so `authenticated` already has SELECT here. The lint must still report 0 rows.
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
 
   rollback to savepoint a;
 
@@ -24,9 +24,10 @@ begin;
   savepoint case_table_view_matview;
 
   ----------------------------------------
-  -- POSITIVE: `anon` has SELECT (via the fixture's PUBLIC default
-  -- grant) on a table, a view, and a materialized view. All three
-  -- relkinds covered by the lint should appear, ordered by object name.
+  -- POSITIVE: `authenticated` has SELECT (via the fixture's PUBLIC
+  -- default grant) on a table, a view, and a materialized view. All
+  -- three relkinds covered by the lint should appear, ordered by
+  -- object name.
   ----------------------------------------
   create table public.internal_api_keys(
     id int primary key,
@@ -44,17 +45,18 @@ begin;
     name,
     metadata->>'type' as object_type,
     cache_key
-  from lint."0026_pg_graphql_anon_table_exposed";
+  from lint."0027_pg_graphql_authenticated_table_exposed";
 
   ----------------------------------------
-  -- RESOLUTION: revoke from anon (and PUBLIC, which anon rides on by
-  -- default). After revoking, has_table_privilege('anon', ...) is false
-  -- and the lint clears.
+  -- RESOLUTION: revoke from authenticated (and PUBLIC, which
+  -- authenticated rides on by default). After revoking,
+  -- has_table_privilege('authenticated', ...) is false and the lint
+  -- clears.
   ----------------------------------------
-  revoke all on public.internal_api_keys from anon, public;
-  revoke all on public.api_key_summary   from anon, public;
-  revoke all on public.api_key_archive   from anon, public;
-  select * from lint."0026_pg_graphql_anon_table_exposed";
+  revoke all on public.internal_api_keys from authenticated, public;
+  revoke all on public.api_key_summary   from authenticated, public;
+  revoke all on public.api_key_archive   from authenticated, public;
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
 
   rollback to savepoint case_table_view_matview;
 
@@ -77,7 +79,7 @@ begin;
     name,
     metadata->>'type' as object_type,
     cache_key
-  from lint."0026_pg_graphql_anon_table_exposed";
+  from lint."0027_pg_graphql_authenticated_table_exposed";
 
   rollback to savepoint case_foreign;
 
@@ -95,42 +97,44 @@ begin;
     name,
     metadata->>'type' as object_type,
     cache_key
-  from lint."0026_pg_graphql_anon_table_exposed";
+  from lint."0027_pg_graphql_authenticated_table_exposed";
 
   rollback to savepoint case_partitioned;
 
-  savepoint case_anon_revoked;
+  savepoint case_authenticated_revoked;
 
   ----------------------------------------
-  -- NEGATIVE: pg_graphql installed and `authenticated` has SELECT, but
-  -- `anon` does NOT. Lint 0026 must not fire (this is precisely the
-  -- "operator followed the original 0026 doc verbatim" state — see
-  -- lint 0027 for the equivalent authenticated-side check).
+  -- NEGATIVE: pg_graphql installed and `anon` has SELECT, but
+  -- `authenticated` does NOT. Lint 0027 must not fire — this is the
+  -- mirror image of 0026's "revoke from anon, keep on authenticated"
+  -- state. It is unusual in practice but verifies the role check is
+  -- independent.
   ----------------------------------------
-  create table public.auth_only_tbl(id int primary key);
-  revoke select on public.auth_only_tbl from public;
-  grant select on public.auth_only_tbl to authenticated;
-  select * from lint."0026_pg_graphql_anon_table_exposed";
+  create table public.anon_only_tbl(id int primary key);
+  revoke select on public.anon_only_tbl from public;
+  grant select on public.anon_only_tbl to anon;
+  select * from lint."0027_pg_graphql_authenticated_table_exposed";
 
-  rollback to savepoint case_anon_revoked;
+  rollback to savepoint case_authenticated_revoked;
 
   savepoint case_column_only_grant;
 
   ----------------------------------------
-  -- POSITIVE (column-level grant only): `anon` has SELECT on a single
-  -- column, no table-level SELECT, and no PUBLIC grant. pg_graphql
-  -- exposes any relation with at least one selectable column, so the
-  -- lint must too. has_table_privilege would have missed this case.
+  -- POSITIVE (column-level grant only): `authenticated` has SELECT on
+  -- a single column, no table-level SELECT, and no PUBLIC grant.
+  -- pg_graphql exposes any relation with at least one selectable
+  -- column, so the lint must too. has_table_privilege would have
+  -- missed this case.
   ----------------------------------------
   create table public.col_grant_only(id int primary key, secret text);
   revoke select on public.col_grant_only from public, anon, authenticated;
-  grant select (id) on public.col_grant_only to anon;
+  grant select (id) on public.col_grant_only to authenticated;
 
   select
     name,
     metadata->>'type' as object_type,
     cache_key
-  from lint."0026_pg_graphql_anon_table_exposed";
+  from lint."0027_pg_graphql_authenticated_table_exposed";
 
   rollback to savepoint case_column_only_grant;
 

--- a/test/sql/0028_anon_security_definer_function_executable.sql
+++ b/test/sql/0028_anon_security_definer_function_executable.sql
@@ -1,0 +1,112 @@
+begin;
+  set local search_path = '';
+
+  -- BASELINE: empty user-schema, no rows
+  select * from lint."0028_anon_security_definer_function_executable";
+
+  savepoint a;
+
+  ----------------------------------------
+  -- NEGATIVE EXAMPLE: SECURITY INVOKER function, even with EXECUTE
+  -- granted to anon (via the Postgres default to PUBLIC), must not
+  -- fire. Invoker functions run as the caller and RLS still applies.
+  ----------------------------------------
+  create function public.invoker_func() returns int
+    language sql
+    security invoker
+    as $$ select 1 $$;
+  -- Postgres default grants EXECUTE on functions to PUBLIC, so anon
+  -- has EXECUTE here without an explicit grant.
+  select * from lint."0028_anon_security_definer_function_executable";
+
+  rollback to savepoint a;
+
+  savepoint case_definer_default_grant;
+
+  ----------------------------------------
+  -- POSITIVE: SECURITY DEFINER function in public, EXECUTE granted to
+  -- anon via the Postgres default to PUBLIC. This is the most common
+  -- accidental exposure — the developer never granted EXECUTE
+  -- explicitly, the default did it.
+  ----------------------------------------
+  create function public.priv_op(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    metadata->>'security_definer' as security_definer,
+    cache_key
+  from lint."0028_anon_security_definer_function_executable";
+
+  ----------------------------------------
+  -- RESOLUTION: revoke EXECUTE from anon and from PUBLIC. After
+  -- revoking, has_function_privilege('anon', ...) is false and the
+  -- lint clears.
+  ----------------------------------------
+  revoke execute on function public.priv_op(int) from anon, public;
+  select * from lint."0028_anon_security_definer_function_executable";
+
+  rollback to savepoint case_definer_default_grant;
+
+  savepoint case_overloads;
+
+  ----------------------------------------
+  -- POSITIVE (overloads): two SECURITY DEFINER functions sharing a
+  -- name but with different argument lists. Each must produce a
+  -- separate finding with a unique cache_key based on the argument
+  -- signature.
+  ----------------------------------------
+  create function public.dispatch(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  create function public.dispatch(target_id int, label text) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    cache_key
+  from lint."0028_anon_security_definer_function_executable";
+
+  rollback to savepoint case_overloads;
+
+  savepoint case_definer_revoked;
+
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function with EXECUTE explicitly
+  -- revoked from anon (and PUBLIC). Lint must not fire even though
+  -- `authenticated` may still have EXECUTE — that's lint 0029's job.
+  ----------------------------------------
+  create function public.admin_only() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  revoke execute on function public.admin_only() from public, anon;
+  select * from lint."0028_anon_security_definer_function_executable";
+
+  rollback to savepoint case_definer_revoked;
+
+  savepoint case_system_schema;
+
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function in a system schema (auth)
+  -- must not fire even with EXECUTE to anon — system schemas are
+  -- excluded.
+  ----------------------------------------
+  create function auth.system_definer() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  select * from lint."0028_anon_security_definer_function_executable";
+
+  rollback to savepoint case_system_schema;
+
+rollback;

--- a/test/sql/0029_authenticated_security_definer_function_executable.sql
+++ b/test/sql/0029_authenticated_security_definer_function_executable.sql
@@ -1,0 +1,107 @@
+begin;
+  set local search_path = '';
+
+  -- BASELINE: empty user-schema, no rows
+  select * from lint."0029_authenticated_security_definer_function_executable";
+
+  savepoint a;
+
+  ----------------------------------------
+  -- NEGATIVE EXAMPLE: SECURITY INVOKER function, even with EXECUTE
+  -- granted to authenticated (via the Postgres default to PUBLIC),
+  -- must not fire. Invoker functions run as the caller and RLS still
+  -- applies.
+  ----------------------------------------
+  create function public.invoker_func() returns int
+    language sql
+    security invoker
+    as $$ select 1 $$;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+
+  rollback to savepoint a;
+
+  savepoint case_definer_default_grant;
+
+  ----------------------------------------
+  -- POSITIVE: SECURITY DEFINER function in public, EXECUTE granted to
+  -- authenticated via the Postgres default to PUBLIC.
+  ----------------------------------------
+  create function public.priv_op(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    metadata->>'security_definer' as security_definer,
+    cache_key
+  from lint."0029_authenticated_security_definer_function_executable";
+
+  ----------------------------------------
+  -- RESOLUTION: revoke EXECUTE from authenticated and from PUBLIC.
+  ----------------------------------------
+  revoke execute on function public.priv_op(int) from authenticated, public;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+
+  rollback to savepoint case_definer_default_grant;
+
+  savepoint case_overloads;
+
+  ----------------------------------------
+  -- POSITIVE (overloads): two SECURITY DEFINER functions sharing a
+  -- name but with different argument lists. Each must produce a
+  -- separate finding with a unique cache_key based on the argument
+  -- signature.
+  ----------------------------------------
+  create function public.dispatch(target_id int) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+  create function public.dispatch(target_id int, label text) returns int
+    language sql
+    security definer
+    as $$ select target_id $$;
+
+  select
+    name,
+    metadata->>'name' as func_name,
+    metadata->>'arguments' as func_args,
+    cache_key
+  from lint."0029_authenticated_security_definer_function_executable";
+
+  rollback to savepoint case_overloads;
+
+  savepoint case_definer_revoked;
+
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function with EXECUTE explicitly
+  -- revoked from authenticated (and PUBLIC). Lint must not fire even
+  -- though `anon` may still have EXECUTE — that's lint 0028's job.
+  ----------------------------------------
+  create function public.user_only() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  revoke execute on function public.user_only() from public, authenticated;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+
+  rollback to savepoint case_definer_revoked;
+
+  savepoint case_system_schema;
+
+  ----------------------------------------
+  -- NEGATIVE: SECURITY DEFINER function in a system schema (auth)
+  -- must not fire even with EXECUTE to authenticated — system schemas
+  -- are excluded.
+  ----------------------------------------
+  create function auth.system_definer() returns int
+    language sql
+    security definer
+    as $$ select 1 $$;
+  select * from lint."0029_authenticated_security_definer_function_executable";
+
+  rollback to savepoint case_system_schema;
+
+rollback;

--- a/test/sql/queries_are_unionable.sql
+++ b/test/sql/queries_are_unionable.sql
@@ -50,6 +50,12 @@ begin;
     union all
     select * from lint."0025_public_bucket_allows_listing"
     union all
-    select * from lint."0026_pg_graphql_anon_table_exposed";
+    select * from lint."0026_pg_graphql_anon_table_exposed"
+    union all
+    select * from lint."0027_pg_graphql_authenticated_table_exposed"
+    union all
+    select * from lint."0028_anon_security_definer_function_executable"
+    union all
+    select * from lint."0029_authenticated_security_definer_function_executable";
 
 rollback;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                   
   
  Closes correctness gaps in splinter's pg_graphql introspection coverage and adds a paired pair of lints for the SECURITY DEFINER function exposure path, which is often the largest data-leak surface in practice. After this PR, the four lints below cover the four direct exposure paths to public-API roles: anon-vs-authenticated ×  
  tables-vs-functions.
                                                                                                                                                                                                                                                                                                                                            
  The four lints are:

  - 0026_pg_graphql_anon_table_exposed (WARN) — a relation is visible in pg_graphql introspection because anon can read at least one column.                                                                                                                                                                                                
  - 0027_pg_graphql_authenticated_table_exposed (WARN, new) — a relation is visible in pg_graphql introspection because authenticated can read at least one column.
  - 0028_anon_security_definer_function_executable (WARN, new) — a SECURITY DEFINER function in a user schema is executable by anon.                                                                                                                                                                                                        
  - 0029_authenticated_security_definer_function_executable (WARN, new) — a SECURITY DEFINER function in a user schema is executable by authenticated.                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                            
  All four are EXTERNAL, SECURITY. The name column on 0026 is unchanged so existing Studio integrations (supabase/supabase #45253) keep matching.                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                            
  Conditions covered                                                                                                                                                                                                                                                                                                                        
                  
  0026 — pg_graphql introspection (anon)                                                                                                                                                                                                                                                                                                    
   
  Fires when all of the following are true: the pg_graphql extension is installed; the relation lives in a non-system schema; the relation's relkind is one of 'r' (table), 'v' (view), 'm' (materialized view), or 'f' (foreign table); and the anon role has SELECT on at least one column of the relation. The privilege check is        
  column-level (has_column_privilege over pg_attribute), so both table-level grants and column-only grants such as GRANT SELECT (col) ON t TO anon fire the lint. Metadata exposed: schema, name, type.
                                                                                                                                                                                                                                                                                                                                            
  0027 — pg_graphql introspection (authenticated)

  Same conditions as 0026 against the authenticated role. This is the second half of the introspection check: in default Supabase projects anon and authenticated start with identical default-privilege grants, so revoking from one alone usually leaves the introspection response unchanged for the other. An operator following the    
  original 0026 doc verbatim — "revoke from anon, grant to authenticated" — would clear 0026 and still serve a byte-for-byte unchanged introspection response to every signed-up user. 0027 catches that residual exposure. Metadata exposed: schema, name, type.
                                                                                                                                                                                                                                                                                                                                            
  0028 — SECURITY DEFINER function executable by anon                                                                                                                                                                                                                                                                                       
   
  Fires when all of the following are true: the function lives in a non-system schema; the function has prosecdef = true; and the anon role has EXECUTE on the function (direct grant, role membership, or via PUBLIC — which is the Postgres default for new functions). Does not gate on pg_graphql being installed: PostgREST exposes the
   function at /rest/v1/rpc/<name> independently. Metadata exposed: schema, name, arguments, language, security_definer. The arguments value comes from pg_get_function_identity_arguments so overloaded functions produce one finding per signature with a distinct cache_key.
                                                                                                                                                                                                                                                                                                                                            
  SECURITY INVOKER functions are deliberately excluded — they execute as the caller and RLS still applies to any tables they touch. The risk pattern these lints target is RLS bypass via privilege escalation in SECURITY DEFINER. The underlying-table risk for SECURITY INVOKER functions is owned by lints 0008 and 0013.               
   
  0029 — SECURITY DEFINER function executable by authenticated                                                                                                                                                                                                                                                                              
                  
  Same conditions as 0028 against the authenticated role. Same metadata shape.                                                                                                                                                                                                                                                              
   
  Changes to existing 0026 behaviour                                                                                                                                                                                                                                                                                                        
                  
  0026 was originally added in PR #158. Three correctness gaps are fixed in this PR.                                                                                                                                                                                                                                                        
   
  The first is role coverage. The original lint only checked anon. pg_graphql introspection runs under whichever role the caller's JWT claims, so anon and authenticated see independent introspection responses. The original remediation in the docs ("revoke from anon, grant to authenticated") could be followed verbatim and leave the
   introspection response served to every signed-up user byte-for-byte unchanged. The fix is to keep 0026 focused on anon, add a parallel 0027 for authenticated, and rewrite the docs to make the pairing explicit.
                                                                                                                                                                                                                                                                                                                                            
  The second is the relkind filter. The original filter was ('r','p','v','m'). pg_graphql's actual filter at load_sql_context.sql:395-400 is ('r','v','m','f'). The fix is to drop 'p' (partitioned table roots are not exposed by pg_graphql; their leaf partitions remain covered as 'r') and add 'f' (foreign tables, which pg_graphql   
  does expose).
                                                                                                                                                                                                                                                                                                                                            
  The third is privilege-predicate granularity. The original used has_table_privilege(role, oid, 'SELECT'). pg_graphql actually uses has_column_privilege per column at load_sql_context.sql:327 (populating is_selectable) and sql_types.rs:594 (is_any_column_selectable returning columns.iter().any(|x| x.permissions.is_selectable)). A
   relation where the role has only a column-level grant — GRANT SELECT (some_col) ON t TO anon — would be exposed by pg_graphql but missed by the lint. Insert/Update/Delete entrypoints share the same prerequisite (graphql.rs:194-209), so this gap also masked mutation exposures. The fix is to replace has_table_privilege with an
  EXISTS over pg_attribute calling has_column_privilege, filtered to live columns (attnum > 0 AND NOT attisdropped). This is a strict superset of the previous behaviour: anything that fired before still fires, and column-only grants now fire too.                                                                                      
                  
  Why these are paired in one PR                                                                                                                                                                                                                                                                                                            
   
  The four lints are mutually reinforcing. An operator who acts on 0026 alone could clear it and still be wide open via 0027, 0028, or 0029. Shipping them together so the docs can cross-link, the remediation guidance can land coherently, and Studio can render the related findings as a coherent group avoids review thrash and       
  prevents a partial mitigation from looking complete. The pg_graphql introspection lints (0026/0027) and the SECURITY DEFINER function lints (0028/0029) cover related-but-distinct exposure paths; the docs cross-reference each other so an operator reading any one finding is pointed at the others.
                                                                                                                                                                                                                                                                                                                                            
  Documentation                                                                                                                                                                                                                                                                                                                             
   
  Each doc has the same up-front structure: level, summary, ramification, a "see also" call-out cross-linking the paired lint, and an "If you are not using pg_graphql, disable it" call-out near the top. For 0026/0027 disabling pg_graphql fully closes the introspection surface. For 0028/0029 it only closes the /graphql/v1 half —   
  the function is still callable via PostgREST /rest/v1/rpc, so the lint keeps firing and the rest of the doc still applies. The doc says so explicitly in each case.
                                                                                                                                                                                                                                                                                                                                            
  The remediation sections cover the same three options across all four lints: revoke (always including PUBLIC because Postgres default grants live there), narrower per-relation revoke for the targeted finding, and full endpoint shutdown for projects that do not use /graphql/v1 at all. Each doc also has verification snippets      
  showing the exact curl calls to confirm the fix from both /graphql/v1 and /rest/v1/rpc, plus a quick-reference SQL table and a false-positives section.
                                                                                                                                                                                                                                                                                                                                            
  Test coverage                                                                                                                                                                                                                                                                                                                             
   
  0026's test covers: baseline (no extension, 0 rows); pg_graphql-not-installed negative; positive on table + view + materialized view together (all three relkinds in the filter, asserting 3 rows alphabetically ordered); revoke-clears resolution; a foreign-table positive case proving relkind='f' fires; a partitioned-table mixed   
  case proving the root relkind='p' does NOT fire while the leaf 'r' does; a negative case where anon is revoked but authenticated keeps SELECT (the exact "operator followed the original 0026 doc" state, asserts 0 rows); and a column-only-grant positive case proving GRANT SELECT (id) ON t TO anon fires the lint without any
  table-level or PUBLIC grant.                                                                                                                                                                                                                                                                                                              
                  
  0027's test mirrors the same shape against authenticated.                                                                                                                                                                                                                                                                                 
   
  0028's test covers: baseline; SECURITY INVOKER negative (proving the prosecdef = true filter works); SECURITY DEFINER positive with the default PUBLIC EXECUTE grant (the most common accidental exposure, since Postgres' default is EXECUTE to PUBLIC); revoke-clears resolution; an overload positive case proving two functions       
  sharing a name with different argument lists produce two findings with distinct cache_keys driven by pg_get_function_identity_arguments; a DEFINER-but-EXECUTE-revoked negative; and a DEFINER-in-system-schema negative confirming the exclusion list.
                                                                                                                                                                                                                                                                                                                                            
  0029's test mirrors the same shape against authenticated.

  queries_are_unionable is extended with the two new union members and confirms column-shape parity across the suite.                                                                                                                                                                                                                       
   
  All 28 tests pass under bin/installcheck against supabase/postgres:15.1.1.13.                                                                                                                                                                                                                                                             
                  
  Other changes                                                                                                                                                                                                                                                                                                                             
                  
  bin/installcheck adds -f lints/0027*.sql -f lints/0028*.sql -f lints/0029*.sql so the new lints load alongside the rest. splinter.sql is regenerated via bin/compile.py (1547 → 1810 lines) and includes all four lints in the bundled UNION ALL.                                                                                         
   
  The shared system-schema exclusion list — copied across most lint files — listed 'pgtle' twice. This was swept across 18 lint files. Purely cosmetic, no behavioural change, but worth doing once to prevent future copy-paste.                                                                                                           
                  
                                                                                                                                                                                                                                                                                                           
                  
  Verification

  bin/compile.py
  SUPABASE_VERSION=15.1.1.13 docker-compose -f dockerfiles/docker-compose.yml run --build --rm test
  # All 28 tests passed.                                                                                                                                                                                                                                                                                                                    
   
  Files                                                                                                                                                                                                                                                                                                                                     
                  
  New: lints/0027_pg_graphql_authenticated_table_exposed.sql, lints/0028_anon_security_definer_function_executable.sql, lints/0029_authenticated_security_definer_function_executable.sql, the matching three docs under docs/, the matching three test SQL files under test/sql/, and the matching three expected-output files under       
  test/expected/. 
                                                                                                                                                                                                                                                                                                                                            
  Modified: lints/0026_pg_graphql_anon_table_exposed.sql for relkind / column-level privilege / comments / cross-reference; docs/0026_pg_graphql_anon_table_exposed.md for the disable-extension callout / relkind note / cross-reference / remediation alignment; test/sql/0026_pg_graphql_anon_table_exposed.sql and its expected output; 
  test/sql/queries_are_unionable.sql and its expected output; bin/installcheck; splinter.sql. Plus 17 other lints/*.sql files where the duplicate 'pgtle' was swept from the system-schema exclusion list.
