### PR TITLE
fix: set pgrst.db_schemas in 0028/0029 tests

### DIFF
--- a/test/expected/0028_anon_security_definer_function_executable.out
+++ b/test/expected/0028_anon_security_definer_function_executable.out
@@ -1,5 +1,6 @@
 begin;
   set local search_path = '';
+  set local pgrst.db_schemas = 'public';
   -- BASELINE: empty user-schema, no rows
   select * from lint."0028_anon_security_definer_function_executable";
  name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 

--- a/test/expected/0029_authenticated_security_definer_function_executable.out
+++ b/test/expected/0029_authenticated_security_definer_function_executable.out
@@ -1,6 +1,7 @@
 NOTICE:  identifier "pg_regress/0029_authenticated_security_definer_function_executable" will be truncated to "pg_regress/0029_authenticated_security_definer_function_executa"
 begin;
   set local search_path = '';
+  set local pgrst.db_schemas = 'public';
   -- BASELINE: empty user-schema, no rows
   select * from lint."0029_authenticated_security_definer_function_executable";
  name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 

--- a/test/sql/0028_anon_security_definer_function_executable.sql
+++ b/test/sql/0028_anon_security_definer_function_executable.sql
@@ -1,5 +1,6 @@
 begin;
   set local search_path = '';
+  set local pgrst.db_schemas = 'public';
 
   -- BASELINE: empty user-schema, no rows
   select * from lint."0028_anon_security_definer_function_executable";

--- a/test/sql/0029_authenticated_security_definer_function_executable.sql
+++ b/test/sql/0029_authenticated_security_definer_function_executable.sql
@@ -1,5 +1,6 @@
 begin;
   set local search_path = '';
+  set local pgrst.db_schemas = 'public';
 
   -- BASELINE: empty user-schema, no rows
   select * from lint."0029_authenticated_security_definer_function_executable";


### PR DESCRIPTION
## Summary

PR #160 added a `pgrst.db_schemas` filter to lints `0028` and `0029` to scope function findings to schemas PostgREST actually exposes via `/rest/v1/rpc`. The test SQL files for those lints were not updated to set the GUC, so every positive case in the test stopped firing — the lint correctly returns 0 rows when `pgrst.db_schemas` is unset, which makes "DEFINER function with EXECUTE to anon" look like a non-finding to the test harness.

This PR sets `set local pgrst.db_schemas = 'public';` at the top of both test files, mirroring the established pattern from `test/sql/0023_sensitive_columns_exposed.sql` (which uses the same filter for the same reason).

## Why this slipped past CI

#160's CI run actually reported `2 of 28 tests failed` in its log, but the workflow turned green. The cause is in `dockerfiles/docker-compose.yml`:

```yaml
command:
  - bash
  - -c
  - "./bin/installcheck; cp /home/splinter/regression.diffs ... 2>/dev/null || true"
```

`bash -c "A; B || true"` returns the exit code of the last command — `cp ... || true`, which is always 0 — so the container exits 0 even when `installcheck` exits non-zero. The actions run conclusion is therefore success regardless of pg_regress results.

Two tactical options for fixing that, neither in scope for this PR:

1. Replace the `;`-and-`|| true` chain with `./bin/installcheck; rc=$?; cp ... 2>/dev/null || true; exit $rc` so the cp still runs (for diagnostics) but the installcheck exit code is preserved.
2. Move the cp into a separate compose service or a `post_command` hook so the test container can fail cleanly.

Worth a follow-up so future test breakage cannot hide behind a green check.

## Verification

```bash
SUPABASE_VERSION=15.1.1.13 docker-compose -f dockerfiles/docker-compose.yml run --build --rm test
# All 28 tests passed.
```

Confirmed locally on `supabase/postgres:15.1.1.13`. Each positive case in `0028` and `0029` now produces the expected row counts:

- `case_definer_default_grant`: 1 row (SECURITY DEFINER function created with default `PUBLIC` EXECUTE).
- `case_overloads`: 2 rows with distinct `cache_key` values driven by `pg_get_function_identity_arguments`.
- All negative cases (INVOKER, EXECUTE-revoked, system-schema) continue to return 0 rows.

## Files

- `test/sql/0028_anon_security_definer_function_executable.sql` — adds `set local pgrst.db_schemas = 'public';`
- `test/sql/0029_authenticated_security_definer_function_executable.sql` — same.
- `test/expected/0028_anon_security_definer_function_executable.out` — re-promoted to include the new echo line.
- `test/expected/0029_authenticated_security_definer_function_executable.out` — same.