### PR TITLE
Add lint for PostgreSQL 17 deprecated extensions

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -52,7 +52,7 @@ else
 fi
 
 # Execute the test fixtures
-psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -d contrib_regression
+psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -f lints/0025*.sql -d contrib_regression
 
 # Run tests
 ${REGRESS} --use-existing --dbname=contrib_regression --inputdir=${TESTDIR} ${TESTS}

--- a/lints/0025_pg17_deprecated_extensions.sql
+++ b/lints/0025_pg17_deprecated_extensions.sql
@@ -1,0 +1,29 @@
+create view lint."0025_pg17_deprecated_extensions" as
+
+select
+    'pg17_deprecated_extensions' as name,
+    'PG17 Deprecated Extensions' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects extensions that are deprecated in PostgreSQL 17 images.' as description,
+    format(
+    'Extension `%s` is deprecated in PostgreSQL 17 images. Consider removing or replacing it before upgrading.',
+    pe.extname
+) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0025_pg17_deprecated_extensions' as remediation,
+    jsonb_build_object(
+    'extension_name', pe.extname
+) as metadata,
+    format(
+    'pg17_deprecated_extension_%s',
+    pe.extname
+) as cache_key
+from
+    pg_catalog.pg_extension pe
+where
+    pe.extname in (
+        'plv8',
+        'timescaledb',
+        'adminpack'
+    );

--- a/test/expected/0025_pg17_deprecated_extensions.out
+++ b/test/expected/0025_pg17_deprecated_extensions.out
@@ -1,0 +1,16 @@
+begin;
+  -- 0 issues initially
+  select * from lint."0025_pg17_deprecated_extensions";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  create extension adminpack;
+  -- 1 issue
+  select * from lint."0025_pg17_deprecated_extensions";
+            name            |           title            | level |  facing  | categories |                           description                           |                                                      detail                                                      |                                          remediation                                           |            metadata             |              cache_key              
+----------------------------+----------------------------+-------+----------+------------+-----------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+---------------------------------+-------------------------------------
+ pg17_deprecated_extensions | PG17 Deprecated Extensions | WARN  | EXTERNAL | {SECURITY} | Detects extensions that are deprecated in PostgreSQL 17 images. | Extension `adminpack` is deprecated in PostgreSQL 17 images. Consider removing or replacing it before upgrading. | https://supabase.com/docs/guides/database/database-linter?lint=0025_pg17_deprecated_extensions | {"extension_name": "adminpack"} | pg17_deprecated_extension_adminpack
+(1 row)
+
+rollback;

--- a/test/sql/0025_pg17_deprecated_extensions.sql
+++ b/test/sql/0025_pg17_deprecated_extensions.sql
@@ -1,0 +1,11 @@
+begin;
+
+  -- 0 issues initially
+  select * from lint."0025_pg17_deprecated_extensions";
+
+  create extension adminpack;
+
+  -- 1 issue
+  select * from lint."0025_pg17_deprecated_extensions";
+
+rollback;


### PR DESCRIPTION
## Summary

Adds a new lint to detect extensions that are deprecated in PostgreSQL 17 images.

The lint warns when any of the following extensions are installed:

* `adminpack`
* `plv8`
* `timescaledb`

These extensions are deprecated in PostgreSQL 17 images and may require removal or replacement before upgrading.

## Changes

* Added `0025_pg17_deprecated_extensions` lint
* Added regression test for deprecated extension detection
* Added expected test output
* Updated test runner to include the new lint

## Example

When a deprecated extension is installed:

```sql
create extension adminpack;
```

The lint returns a warning indicating that the extension is deprecated in PostgreSQL 17 images and should be reviewed before upgrading.

## Related Issue

Closes #105
