### PR TITLE
perf: make pg_depend/namespace lint filters index-friendly on large catalogs

### DIFF
--- a/lints/0001_unindexed_foreign_keys.sql
+++ b/lints/0001_unindexed_foreign_keys.sql
@@ -2,7 +2,7 @@ create view lint."0001_unindexed_foreign_keys" as
 
 with foreign_keys as (
     select
-        cl.relnamespace::regnamespace::text as schema_name,
+        ns.nspname as schema_name,
         cl.relname as table_name,
         cl.oid as table_oid,
         ct.conname as fkey_name,
@@ -11,13 +11,16 @@ with foreign_keys as (
         pg_catalog.pg_constraint ct
         join pg_catalog.pg_class cl -- fkey owning table
             on ct.conrelid = cl.oid
+        join pg_catalog.pg_namespace ns
+            on cl.relnamespace = ns.oid
         left join pg_catalog.pg_depend d
             on d.objid = cl.oid
             and d.deptype = 'e'
+            and d.classid = 'pg_catalog.pg_class'::regclass
     where
         ct.contype = 'f' -- foreign key constraints
         and d.objid is null -- exclude tables that are dependencies of extensions
-        and cl.relnamespace::regnamespace::text not in (
+        and ns.nspname not in (
             'pg_catalog', 'information_schema', 'auth', 'storage', 'vault', 'extensions'
         )
 ),
@@ -61,6 +64,7 @@ from
     left join pg_catalog.pg_depend dep
         on idx.table_oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     idx.index_ is null
     and fk.schema_name not in (

--- a/lints/0004_no_primary_key.sql
+++ b/lints/0004_no_primary_key.sql
@@ -32,6 +32,7 @@ from
     left join pg_catalog.pg_depend dep
         on pgc.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     pgc.relkind = 'r' -- regular tables
     and pgns.nspname not in (

--- a/lints/0005_unused_index.sql
+++ b/lints/0005_unused_index.sql
@@ -33,6 +33,7 @@ from
     left join pg_catalog.pg_depend dep
         on psui.relid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     psui.idx_scan = 0
     and not pi.indisunique

--- a/lints/0006_multiple_permissive_policies.sql
+++ b/lints/0006_multiple_permissive_policies.sql
@@ -39,7 +39,8 @@ from
         or p.polroles = array[0::oid]
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
-        and dep.deptype = 'e',
+        and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass,
     lateral (
         select x.cmd
         from unnest((

--- a/lints/0007_policy_exists_rls_disabled.sql
+++ b/lints/0007_policy_exists_rls_disabled.sql
@@ -33,6 +33,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (

--- a/lints/0008_rls_enabled_no_policy.sql
+++ b/lints/0008_rls_enabled_no_policy.sql
@@ -32,6 +32,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (

--- a/lints/0009_duplicate_index.sql
+++ b/lints/0009_duplicate_index.sql
@@ -40,6 +40,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind in ('r', 'm') -- tables and materialized views
     and n.nspname not in (

--- a/lints/0010_security_definer_view.sql
+++ b/lints/0010_security_definer_view.sql
@@ -30,6 +30,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'v'
     and (

--- a/lints/0011_function_search_path_mutable.sql
+++ b/lints/0011_function_search_path_mutable.sql
@@ -31,6 +31,7 @@ from
     left join pg_catalog.pg_depend dep
         on p.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_proc'::regclass
 where
     n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'

--- a/lints/0016_materialized_view_in_api.sql
+++ b/lints/0016_materialized_view_in_api.sql
@@ -30,6 +30,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'm'
     and (

--- a/lints/0017_foreign_table_in_api.sql
+++ b/lints/0017_foreign_table_in_api.sql
@@ -30,6 +30,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'f'
     and (

--- a/splinter.sql
+++ b/splinter.sql
@@ -3,7 +3,7 @@ set local search_path = '';
 (
 with foreign_keys as (
     select
-        cl.relnamespace::regnamespace::text as schema_name,
+        ns.nspname as schema_name,
         cl.relname as table_name,
         cl.oid as table_oid,
         ct.conname as fkey_name,
@@ -12,13 +12,16 @@ with foreign_keys as (
         pg_catalog.pg_constraint ct
         join pg_catalog.pg_class cl -- fkey owning table
             on ct.conrelid = cl.oid
+        join pg_catalog.pg_namespace ns
+            on cl.relnamespace = ns.oid
         left join pg_catalog.pg_depend d
             on d.objid = cl.oid
             and d.deptype = 'e'
+            and d.classid = 'pg_catalog.pg_class'::regclass
     where
         ct.contype = 'f' -- foreign key constraints
         and d.objid is null -- exclude tables that are dependencies of extensions
-        and cl.relnamespace::regnamespace::text not in (
+        and ns.nspname not in (
             'pg_catalog', 'information_schema', 'auth', 'storage', 'vault', 'extensions'
         )
 ),
@@ -62,6 +65,7 @@ from
     left join pg_catalog.pg_depend dep
         on idx.table_oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     idx.index_ is null
     and fk.schema_name not in (
@@ -296,6 +300,7 @@ from
     left join pg_catalog.pg_depend dep
         on pgc.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     pgc.relkind = 'r' -- regular tables
     and pgns.nspname not in (
@@ -343,6 +348,7 @@ from
     left join pg_catalog.pg_depend dep
         on psui.relid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     psui.idx_scan = 0
     and not pi.indisunique
@@ -392,7 +398,8 @@ from
         or p.polroles = array[0::oid]
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
-        and dep.deptype = 'e',
+        and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass,
     lateral (
         select x.cmd
         from unnest((
@@ -459,6 +466,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (
@@ -504,6 +512,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'r' -- regular tables
     and n.nspname not in (
@@ -558,6 +567,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind in ('r', 'm') -- tables and materialized views
     and n.nspname not in (
@@ -603,6 +613,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'v'
     and (
@@ -657,6 +668,7 @@ from
     left join pg_catalog.pg_depend dep
         on p.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_proc'::regclass
 where
     n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
@@ -830,6 +842,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'm'
     and (
@@ -873,6 +886,7 @@ from
     left join pg_catalog.pg_depend dep
         on c.oid = dep.objid
         and dep.deptype = 'e'
+        and dep.classid = 'pg_catalog.pg_class'::regclass
 where
     c.relkind = 'f'
     and (


### PR DESCRIPTION
## Problem

On databases with very large catalogs (many schemas/tables and a multi-million-row `pg_depend`), several lints hit `statement_timeout`. Two query anti-patterns are responsible.

## Fix 1 — constrain the extension-ownership anti-joins by `classid`

Every structural lint excludes extension-owned objects via:

```sql
left join pg_catalog.pg_depend dep on <x>.oid = dep.objid and dep.deptype = 'e'
... where dep.objid is null
```

`pg_depend`'s index is on `(classid, objid, objsubid)`. Because the join doesn't constrain the **leading** `classid` column, the index can't be used and the planner **seq-scans `pg_depend` per outer row** — `O(objects × pg_depend rows)`.

Adding `and dep.classid = 'pg_catalog.pg_class'::regclass` (`'pg_catalog.pg_proc'::regclass` for the function lint, whose objects live in `pg_proc`) pins both leading index columns → an index seek per row. This is also **strictly more correct**: `pg_depend.objid` is only unique *within* a `classid`.

Affects: `0001`, `0004`, `0005`, `0006`, `0007`, `0008`, `0009`, `0010`, `0011`, `0016`, `0017`.

## Fix 2 — `0001_unindexed_foreign_keys`: drop the per-row `regnamespace` cast

It evaluated `relnamespace::regnamespace::text` (a syscache lookup) per `pg_constraint` row in the `WHERE`. Replaced with a join to `pg_namespace` filtering on `nspname` — the idiom 23/28 lints already use; `0001` was the only outlier. Identical output for normal schema names, no per-row lookups. (Deliberately **not** `'schema'::regnamespace` literals, which would error on DBs missing an excluded schema.)

Refs PSQL-1298