### PR TITLE
fix: default API-exposure lints to public schema when pgrst.db_schemas is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Splinter maintains a set of lints for Supabase projects. It uses SQL queries to 
 
 If you are only interested in linting a project, a single query containing the latest version of all lints is availble in splinter.sql in the repo root.
 
+### API-exposure lints and `pgrst.db_schemas`
+
+Several lints (e.g. `auth_users_exposed`, `materialized_view_in_api`, `foreign_table_in_api`) only report objects that are reachable through the Data API — that is, objects in a schema listed in the `pgrst.db_schemas` setting. PostgREST sets this value at runtime, but it is **not** present in a plain `psql` connection.
+
+When `pgrst.db_schemas` is unset, these lints default to the **`public` schema only**. If your project exposes additional schemas, set the value to match your PostgREST config before running the lints so those schemas are covered too:
+
+```sql
+set pgrst.db_schemas = 'public, graphql_public, ...';
+```
+
+Without this, exposures in non-`public` schemas will not be reported.
+
 ## Lint Interface
 
 Each lint creates a view that returns a common interface. The interface is:

--- a/lints/0002_auth_users_exposed.sql
+++ b/lints/0002_auth_users_exposed.sql
@@ -43,7 +43,7 @@ where
       pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
       or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     -- Exclude self
     and c.relname <> '0002_auth_users_exposed'
     -- There are 3 insecure configurations

--- a/lints/0010_security_definer_view.sql
+++ b/lints/0010_security_definer_view.sql
@@ -38,7 +38,7 @@ where
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
     and substring(pg_catalog.version() from 'PostgreSQL ([0-9]+)') >= '15' -- security invoker was added in pg15
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )

--- a/lints/0013_rls_disabled_in_public.sql
+++ b/lints/0013_rls_disabled_in_public.sql
@@ -35,7 +35,7 @@ where
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     );

--- a/lints/0016_materialized_view_in_api.sql
+++ b/lints/0016_materialized_view_in_api.sql
@@ -37,7 +37,7 @@ where
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )

--- a/lints/0017_foreign_table_in_api.sql
+++ b/lints/0017_foreign_table_in_api.sql
@@ -37,7 +37,7 @@ where
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )

--- a/lints/0019_insecure_queue_exposed_in_api.sql
+++ b/lints/0019_insecure_queue_exposed_in_api.sql
@@ -37,4 +37,4 @@ where
     and n.nspname = 'pgmq' -- tables in the pgmq schema
     and c.relname like 'q_%' -- only queue tables
     -- Constant requirements
-    and 'pgmq_public' = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and 'pgmq_public' = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))

--- a/lints/0023_sensitive_columns_exposed.sql
+++ b/lints/0023_sensitive_columns_exposed.sql
@@ -48,7 +48,7 @@ exposed_tables as (
             pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
             or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
         )
-        and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+        and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
         and n.nspname not in (
             '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )

--- a/lints/0028_anon_security_definer_function_executable.sql
+++ b/lints/0028_anon_security_definer_function_executable.sql
@@ -61,7 +61,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
-            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )

--- a/lints/0029_authenticated_security_definer_function_executable.sql
+++ b/lints/0029_authenticated_security_definer_function_executable.sql
@@ -62,7 +62,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
-            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )

--- a/splinter.sql
+++ b/splinter.sql
@@ -121,7 +121,7 @@ where
       pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
       or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     -- Exclude self
     and c.relname <> '0002_auth_users_exposed'
     -- There are 3 insecure configurations
@@ -621,7 +621,7 @@ where
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
     and substring(pg_catalog.version() from 'PostgreSQL ([0-9]+)') >= '15' -- security invoker was added in pg15
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
@@ -717,7 +717,7 @@ where
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     ))
@@ -849,7 +849,7 @@ where
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
@@ -893,7 +893,7 @@ where
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
     )
-    and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+    and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
     and n.nspname not in (
         '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
     )
@@ -980,7 +980,7 @@ where
     and n.nspname = 'pgmq' -- tables in the pgmq schema
     and c.relname like 'q_%' -- only queue tables
     -- Constant requirements
-    and 'pgmq_public' = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ','))))))
+    and 'pgmq_public' = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ','))))))
 union all
 (
 with constants as (
@@ -1212,7 +1212,7 @@ exposed_tables as (
             pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
             or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')
         )
-        and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+        and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
         and n.nspname not in (
             '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )
@@ -1743,7 +1743,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
-            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )
@@ -1816,7 +1816,7 @@ from
         where
             p.prosecdef = true
             and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
-            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname = any(array(select trim(unnest(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
             and n.nspname not in (
                 '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
             )

--- a/test/expected/0013_rls_disabled_in_public.out
+++ b/test/expected/0013_rls_disabled_in_public.out
@@ -1,3 +1,18 @@
+-- PSQL-1309: lint must still fire when `pgrst.db_schemas` is unset (e.g. running
+-- splinter.sql directly via psql), defaulting to the `public` schema. This block
+-- runs first, in a fresh session where the GUC has never been set (NULL).
+begin;
+  set local search_path = '';
+  -- pgrst.db_schemas intentionally NOT set
+  create table public.unset_guc_tbl( it int primary key );
+  -- 1 issue (defaults to the `public` schema)
+  select * from lint."0013_rls_disabled_in_public";
+          name          |         title          | level |  facing  | categories |                                                 description                                                 |                                 detail                                  |                                        remediation                                         |                            metadata                            |                  cache_key                  
+------------------------+------------------------+-------+----------+------------+-------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------+--------------------------------------------------------------------------------------------+----------------------------------------------------------------+---------------------------------------------
+ rls_disabled_in_public | RLS Disabled in Public | ERROR | EXTERNAL | {SECURITY} | Detects cases where row level security (RLS) has not been enabled on tables in schemas exposed to PostgREST | Table \`public.unset_guc_tbl\` is public, but RLS has not been enabled. | https://supabase.com/docs/guides/database/database-linter?lint=0013_rls_disabled_in_public | {"name": "unset_guc_tbl", "type": "table", "schema": "public"} | rls_disabled_in_public_public_unset_guc_tbl
+(1 row)
+
+rollback;
 begin;
   set local search_path = '';
   set local pgrst.db_schemas = 'public';

--- a/test/sql/0013_rls_disabled_in_public.sql
+++ b/test/sql/0013_rls_disabled_in_public.sql
@@ -1,3 +1,17 @@
+-- PSQL-1309: lint must still fire when `pgrst.db_schemas` is unset (e.g. running
+-- splinter.sql directly via psql), defaulting to the `public` schema. This block
+-- runs first, in a fresh session where the GUC has never been set (NULL).
+begin;
+  set local search_path = '';
+  -- pgrst.db_schemas intentionally NOT set
+
+  create table public.unset_guc_tbl( it int primary key );
+
+  -- 1 issue (defaults to the `public` schema)
+  select * from lint."0013_rls_disabled_in_public";
+rollback;
+
+
 begin;
   set local search_path = '';
   set local pgrst.db_schemas = 'public';


### PR DESCRIPTION
## Problem (PSQL-1309)

The API-exposure lints (`auth_users_exposed`, `materialized_view_in_api`, `foreign_table_in_api`, etc.) only report objects in schemas listed in the `pgrst.db_schemas` setting. PostgREST sets that GUC at runtime, but it is **not** present in a plain `psql` connection.

When `pgrst.db_schemas` is unset, `current_setting('pgrst.db_schemas','t')` returns `NULL` → the schema array resolves to empty → `n.nspname = any('{}')` is always false → the lints **silently return 0 rows** instead of surfacing real exposures. This bites anyone running `splinter.sql` directly as a workaround.

## Fix

Wrap the setting:

```sql
coalesce(current_setting('pgrst.db_schemas', 't'), 'public')
```

- **Unset (`NULL`)** → defaults to the `public` schema (PostgREST's default). ✅ fixes the bug
- **Explicitly empty (`''`)** → left unchanged; `''` means "expose nothing" so the lint correctly reports nothing. This preserves the existing `0017_foreign_table_in_api` contract (`set local pgrst.db_schemas = ''` → 0 rows).

Applied to all 9 affected lints; `splinter.sql` recompiled via `bin/compile.py`.

## Tests

Added a regression block for the unset-GUC path to `0013_rls_disabled_in_public` 

## Docs

README Usage section now documents that only `public` is checked when the GUC is unset, and how to `set pgrst.db_schemas` for other exposed schemas.
