### PR TITLE
feat: add lint 0030 — RLS read policy true when an auth function is NULL

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -52,7 +52,7 @@ else
 fi
 
 # Execute the test fixtures
-psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -f lints/0025*.sql -f lints/0026*.sql -f lints/0027*.sql -f lints/0028*.sql -f lints/0029*.sql -d contrib_regression
+psql -v ON_ERROR_STOP= -f test/fixtures.sql -f lints/0001*.sql -f lints/0002*.sql -f lints/0003*.sql -f lints/0004*.sql -f lints/0005*.sql -f lints/0006*.sql -f lints/0007*.sql -f lints/0008*.sql -f lints/0009*.sql -f lints/0010*.sql -f lints/0011*.sql -f lints/0013*.sql -f lints/0014*.sql -f lints/0015*.sql -f lints/0016*.sql -f lints/0017*.sql -f lints/0018*.sql -f lints/0019*.sql -f lints/0020*.sql -f lints/0021*.sql -f lints/0022*.sql -f lints/0023*.sql -f lints/0024*.sql -f lints/0025*.sql -f lints/0026*.sql -f lints/0027*.sql -f lints/0028*.sql -f lints/0029*.sql -f lints/0030*.sql -d contrib_regression
 
 # Run tests
 ${REGRESS} --use-existing --dbname=contrib_regression --inputdir=${TESTDIR} ${TESTS}

--- a/docs/0030_rls_policy_null_auth_disjunct.md
+++ b/docs/0030_rls_policy_null_auth_disjunct.md
@@ -1,0 +1,68 @@
+**Level:** WARN
+
+**Summary:** An RLS read policy is unconditionally true whenever an auth function returns NULL.
+
+**Ramification:** A policy like `USING (auth.uid() IS NULL OR owner_id = auth.uid())` admits **every row** to any session where `auth.uid()` is NULL — the disjunct short-circuits the intended row scoping.
+
+---
+
+### Rationale
+
+Row Level Security policies are easy to write so that they read like the correct sentence in English while evaluating to *true for every row* in a class of sessions.
+
+The canonical shape is an `OR` whose first branch tests a nullable auth function for NULL:
+
+```sql
+using ( auth.uid() is null or owner_id = auth.uid() )
+```
+
+For any request where `auth.uid()` returns NULL, the `auth.uid() IS NULL` branch is `true`, the `OR` short-circuits, and the policy returns every row of the table — regardless of `owner_id`. The author almost always intended the negation (`auth.uid() IS NOT NULL AND owner_id = auth.uid()`) or simply the scoped predicate, and accidentally turned the policy into a no-op.
+
+This is a **correctness** defect: the predicate is unconditionally true for the NULL-auth case whether or not anonymous access is otherwise intended. Its severity depends on which roles the policy applies to:
+
+- For a policy granted to `public` / `anon`, an ordinary token-less request runs as a role the policy applies to **and** has `auth.uid()` NULL — so every row is readable by unauthenticated callers.
+- For a policy granted only to `authenticated`, a token-less request runs as `anon` (which the policy does not apply to), so the exposure requires an `authenticated`-role session whose `sub` claim is NULL — a narrower, but still incorrect, case.
+
+This lint complements `0024_rls_policy_always_true`: that lint matches a literal `USING (true)` (and only flags it for write commands); this one matches a predicate that is *true for NULL auth* and applies to reads.
+
+The supported nullable auth functions are `auth.uid()`, `auth.jwt()`, `auth.role()`, and `current_setting(name, true)` (the two-argument, `missing_ok => true` form, which returns NULL when unset). The never-NULL identity functions (`current_user`, `session_user`, `current_role`) and the raising form `current_setting(name)` / `current_setting(name, false)` are deliberately **not** treated as nullable and do not trigger the lint.
+
+### How to Resolve
+
+**Option 1 (preferred): drop the `IS NULL` disjunct and keep the scoped predicate.**
+
+```sql
+alter policy "read own" on public.documents
+  using ( owner_id = auth.uid() );
+```
+
+**Option 2: if both branches were intended, AND the auth check instead of OR-ing it.**
+
+```sql
+alter policy "read own" on public.documents
+  using ( auth.uid() is not null and owner_id = auth.uid() );
+```
+
+### Example
+
+Given this problematic configuration:
+
+```sql
+create policy "read own" on public.documents
+  for select to authenticated
+  using ( auth.uid() is null or owner_id = auth.uid() );
+```
+
+Fix:
+
+```sql
+create policy "read own" on public.documents
+  for select to authenticated
+  using ( owner_id = auth.uid() );
+```
+
+### False Positives
+
+- A genuine intent to expose rows to NULL-auth sessions (rare) should be made explicit with a dedicated, documented policy rather than an `IS NULL` disjunct folded into a scoped check — allowlist it if so.
+- The lint only inspects the *top-level* `OR` of the `USING` clause. A NULL-auth check that is gated by a top-level `AND` (e.g. `owner_id = auth.uid() AND (auth.uid() IS NULL OR is_public)`) is not unconditionally true and is **not** flagged.
+- `current_setting(name)` / `current_setting(name, false)` raise an error when the setting is unset rather than returning NULL, so those disjuncts are not treated as a NULL bypass.

--- a/lints/0030_rls_policy_null_auth_disjunct.sql
+++ b/lints/0030_rls_policy_null_auth_disjunct.sql
@@ -1,0 +1,150 @@
+create view lint."0030_rls_policy_null_auth_disjunct" as
+
+-- Detects permissive RLS read policies (SELECT / ALL) whose USING clause has a
+-- top-level OR disjunct that is true when an auth function returns NULL --
+-- e.g. `auth.uid() IS NULL OR owner_id = auth.uid()`, the `auth.jwt()` /
+-- `auth.role()` / `current_setting(name, true)` variants, or the
+-- `NOT (auth.uid() IS NOT NULL)` inversion. For any session where that function
+-- is NULL the disjunct is true, so the whole USING is true and the policy admits
+-- every row. It is a logic error -- the author almost always meant
+-- `IS NOT NULL AND ...` or a scoped predicate -- and is distinct from
+-- 0024 (literal `USING (true)`), which cannot see this shape.
+with policies as (
+    select
+        nsp.nspname as schema_name,
+        pb.tablename as table_name,
+        pc.relrowsecurity as is_rls_active,
+        pa.polname as policy_name,
+        pa.polpermissive as is_permissive,
+        pa.polroles as role_oids,
+        (
+            select array_agg(case when r = 0 then 'public' else r::regrole::text end order by r)
+            from unnest(pa.polroles) as x(r)
+        ) as roles,
+        case pa.polcmd
+            when 'r' then 'SELECT'
+            when 'a' then 'INSERT'
+            when 'w' then 'UPDATE'
+            when 'd' then 'DELETE'
+            when '*' then 'ALL'
+        end as command,
+        pb.qual,
+        -- Normalize: lowercase, strip whitespace (matches 0024's normalization)
+        lower(replace(replace(replace(coalesce(pb.qual, ''), ' ', ''), E'\n', ''), E'\t', '')) as normalized_qual
+    from
+        pg_catalog.pg_policy pa
+        join pg_catalog.pg_class pc
+            on pa.polrelid = pc.oid
+        join pg_catalog.pg_namespace nsp
+            on pc.relnamespace = nsp.oid
+        join pg_catalog.pg_policies pb
+            on pc.relname = pb.tablename
+            and nsp.nspname = pb.schemaname
+            and pa.polname = pb.policyname
+    where
+        pc.relkind = 'r' -- regular tables
+        and nsp.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+),
+candidates as (
+    select
+        p.*,
+        -- (1) Replace each *nullable* auth null-check with a paren-free sentinel:
+        --     the `NOT (<fn> IS NOT NULL)` inversion, then the `<fn> IS NULL` form,
+        --     for auth.uid()/auth.jwt()/auth.role() and current_setting(name, true).
+        --     current_setting(name) / current_setting(name, false) RAISE rather
+        --     than return NULL, so they are deliberately excluded.
+        -- (2) Neutralize any remaining auth.*()/current_setting(...) call parens to
+        --     a paren-free token so only *structural* parens are left to analyze.
+        regexp_replace(
+            regexp_replace(
+                regexp_replace(
+                    regexp_replace(
+                        normalized_qual,
+                        'not\((auth\.(uid|jwt|role)\(\)|current_setting\([^)]*,true\))isnotnull\)', 'xnullchkx', 'g'
+                    ),
+                    '(auth\.(uid|jwt|role)\(\)|current_setting\([^)]*,true\))isnull', 'xnullchkx', 'g'
+                ),
+                'current_setting\([^)]*\)', 'fff', 'g'
+            ),
+            'auth\.(uid|jwt|role)\(\)', 'fff', 'g'
+        ) as sentinel
+    from policies p
+    where
+        is_rls_active
+        and is_permissive
+        -- Read side only: SELECT (and ALL, whose USING is the read filter)
+        and command in ('SELECT', 'ALL')
+        -- Only policies that apply to public / anon / authenticated (as 0024 does)
+        and (
+            role_oids = array[0::oid] -- public (all roles)
+            or exists (
+                select 1
+                from unnest(role_oids) as r
+                where r::regrole::text in ('anon', 'authenticated')
+            )
+        )
+),
+classified as (
+    select
+        c.*,
+        -- strip the single outer paren pair Postgres always deparses around qual
+        regexp_replace(regexp_replace(sentinel, '^\(', ''), '\)$', '') as stripped
+    from candidates c
+),
+analyzed as (
+    select
+        c.*,
+        -- collapse balanced (paren) groups (up to 6 levels) so only the
+        -- top-level connective(s) remain -- distinguishes a top-level OR from an
+        -- OR nested inside an AND (the gated, safe case).
+        regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(
+            stripped,
+            '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'),
+            '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'
+        ) as core
+    from classified c
+)
+select
+    'rls_policy_null_auth_disjunct' as name,
+    'RLS Policy True When Auth Is Null' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects permissive RLS read policies whose USING clause has a top-level OR disjunct that is true when an auth function returns NULL (for example `auth.uid() IS NULL OR ...`). Such a policy admits every row for any session where that function is NULL, which is almost always an inverted-logic mistake rather than intended access.' as description,
+    format(
+        'Table `%s.%s` has a permissive policy `%s` for `%s` whose USING clause is unconditionally true when `auth.uid()` / `auth.jwt()` / `auth.role()` (or `current_setting(..., true)`) is NULL, so it exposes every row to those sessions (roles: %s). This is almost always a logic error -- the author likely intended `IS NOT NULL AND ...` or a scoped check. Remove the `IS NULL` disjunct or replace it with an explicit deny.',
+        schema_name,
+        table_name,
+        policy_name,
+        command,
+        array_to_string(roles, ', ')
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0030_rls_policy_null_auth_disjunct' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table',
+        'policy_name', policy_name,
+        'command', command,
+        'roles', roles,
+        'qual', qual
+    ) as metadata,
+    format(
+        'rls_policy_null_auth_disjunct_%s_%s_%s',
+        schema_name,
+        table_name,
+        policy_name
+    ) as cache_key
+from
+    analyzed
+where
+    -- top-level connective is OR (not a gated AND) ...
+    (core ~ 'or' and core !~ 'and')
+    -- ... and one top-level disjunct is exactly the nullable auth null-check
+    and stripped ~ '(^|or)\(xnullchkx\)($|or)'
+order by
+    schema_name,
+    table_name,
+    policy_name;

--- a/splinter.sql
+++ b/splinter.sql
@@ -1825,3 +1825,153 @@ order by
     schema_name,
     function_name,
     function_args)
+union all
+(
+-- Detects permissive RLS read policies (SELECT / ALL) whose USING clause has a
+-- top-level OR disjunct that is true when an auth function returns NULL --
+-- e.g. `auth.uid() IS NULL OR owner_id = auth.uid()`, the `auth.jwt()` /
+-- `auth.role()` / `current_setting(name, true)` variants, or the
+-- `NOT (auth.uid() IS NOT NULL)` inversion. For any session where that function
+-- is NULL the disjunct is true, so the whole USING is true and the policy admits
+-- every row. It is a logic error -- the author almost always meant
+-- `IS NOT NULL AND ...` or a scoped predicate -- and is distinct from
+-- 0024 (literal `USING (true)`), which cannot see this shape.
+with policies as (
+    select
+        nsp.nspname as schema_name,
+        pb.tablename as table_name,
+        pc.relrowsecurity as is_rls_active,
+        pa.polname as policy_name,
+        pa.polpermissive as is_permissive,
+        pa.polroles as role_oids,
+        (
+            select array_agg(case when r = 0 then 'public' else r::regrole::text end order by r)
+            from unnest(pa.polroles) as x(r)
+        ) as roles,
+        case pa.polcmd
+            when 'r' then 'SELECT'
+            when 'a' then 'INSERT'
+            when 'w' then 'UPDATE'
+            when 'd' then 'DELETE'
+            when '*' then 'ALL'
+        end as command,
+        pb.qual,
+        -- Normalize: lowercase, strip whitespace (matches 0024's normalization)
+        lower(replace(replace(replace(coalesce(pb.qual, ''), ' ', ''), E'\n', ''), E'\t', '')) as normalized_qual
+    from
+        pg_catalog.pg_policy pa
+        join pg_catalog.pg_class pc
+            on pa.polrelid = pc.oid
+        join pg_catalog.pg_namespace nsp
+            on pc.relnamespace = nsp.oid
+        join pg_catalog.pg_policies pb
+            on pc.relname = pb.tablename
+            and nsp.nspname = pb.schemaname
+            and pa.polname = pb.policyname
+    where
+        pc.relkind = 'r' -- regular tables
+        and nsp.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+),
+candidates as (
+    select
+        p.*,
+        -- (1) Replace each *nullable* auth null-check with a paren-free sentinel:
+        --     the `NOT (<fn> IS NOT NULL)` inversion, then the `<fn> IS NULL` form,
+        --     for auth.uid()/auth.jwt()/auth.role() and current_setting(name, true).
+        --     current_setting(name) / current_setting(name, false) RAISE rather
+        --     than return NULL, so they are deliberately excluded.
+        -- (2) Neutralize any remaining auth.*()/current_setting(...) call parens to
+        --     a paren-free token so only *structural* parens are left to analyze.
+        regexp_replace(
+            regexp_replace(
+                regexp_replace(
+                    regexp_replace(
+                        normalized_qual,
+                        'not\((auth\.(uid|jwt|role)\(\)|current_setting\([^)]*,true\))isnotnull\)', 'xnullchkx', 'g'
+                    ),
+                    '(auth\.(uid|jwt|role)\(\)|current_setting\([^)]*,true\))isnull', 'xnullchkx', 'g'
+                ),
+                'current_setting\([^)]*\)', 'fff', 'g'
+            ),
+            'auth\.(uid|jwt|role)\(\)', 'fff', 'g'
+        ) as sentinel
+    from policies p
+    where
+        is_rls_active
+        and is_permissive
+        -- Read side only: SELECT (and ALL, whose USING is the read filter)
+        and command in ('SELECT', 'ALL')
+        -- Only policies that apply to public / anon / authenticated (as 0024 does)
+        and (
+            role_oids = array[0::oid] -- public (all roles)
+            or exists (
+                select 1
+                from unnest(role_oids) as r
+                where r::regrole::text in ('anon', 'authenticated')
+            )
+        )
+),
+classified as (
+    select
+        c.*,
+        -- strip the single outer paren pair Postgres always deparses around qual
+        regexp_replace(regexp_replace(sentinel, '^\(', ''), '\)$', '') as stripped
+    from candidates c
+),
+analyzed as (
+    select
+        c.*,
+        -- collapse balanced (paren) groups (up to 6 levels) so only the
+        -- top-level connective(s) remain -- distinguishes a top-level OR from an
+        -- OR nested inside an AND (the gated, safe case).
+        regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(
+            stripped,
+            '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'),
+            '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'), '\([^()]*\)', '', 'g'
+        ) as core
+    from classified c
+)
+select
+    'rls_policy_null_auth_disjunct' as name,
+    'RLS Policy True When Auth Is Null' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects permissive RLS read policies whose USING clause has a top-level OR disjunct that is true when an auth function returns NULL (for example `auth.uid() IS NULL OR ...`). Such a policy admits every row for any session where that function is NULL, which is almost always an inverted-logic mistake rather than intended access.' as description,
+    format(
+        'Table `%s.%s` has a permissive policy `%s` for `%s` whose USING clause is unconditionally true when `auth.uid()` / `auth.jwt()` / `auth.role()` (or `current_setting(..., true)`) is NULL, so it exposes every row to those sessions (roles: %s). This is almost always a logic error -- the author likely intended `IS NOT NULL AND ...` or a scoped check. Remove the `IS NULL` disjunct or replace it with an explicit deny.',
+        schema_name,
+        table_name,
+        policy_name,
+        command,
+        array_to_string(roles, ', ')
+    ) as detail,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0030_rls_policy_null_auth_disjunct' as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', table_name,
+        'type', 'table',
+        'policy_name', policy_name,
+        'command', command,
+        'roles', roles,
+        'qual', qual
+    ) as metadata,
+    format(
+        'rls_policy_null_auth_disjunct_%s_%s_%s',
+        schema_name,
+        table_name,
+        policy_name
+    ) as cache_key
+from
+    analyzed
+where
+    -- top-level connective is OR (not a gated AND) ...
+    (core ~ 'or' and core !~ 'and')
+    -- ... and one top-level disjunct is exactly the nullable auth null-check
+    and stripped ~ '(^|or)\(xnullchkx\)($|or)'
+order by
+    schema_name,
+    table_name,
+    policy_name)

--- a/test/expected/0030_rls_policy_null_auth_disjunct.out
+++ b/test/expected/0030_rls_policy_null_auth_disjunct.out
@@ -1,0 +1,225 @@
+begin;
+  set local search_path = '';
+  -- BASELINE: 0 issues on empty schema
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  create table public.documents(
+    id int primary key,
+    owner_id uuid,
+    is_public boolean
+  );
+  alter table public.documents enable row level security;
+  ----------------------------------------------------------------
+  -- POSITIVE: auth.uid() IS NULL disjunct, to public -> FLAG
+  ----------------------------------------------------------------
+  create policy "p_public" on public.documents for select to public
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key, metadata->>'roles' as roles, metadata->>'command' as command
+  from lint."0030_rls_policy_null_auth_disjunct";
+                        cache_key                        |   roles    | command 
+---------------------------------------------------------+------------+---------
+ rls_policy_null_auth_disjunct_public_documents_p_public | ["public"] | SELECT
+(1 row)
+
+  drop policy "p_public" on public.documents;
+  -- POSITIVE: to anon -> FLAG
+  create policy "p_anon" on public.documents for select to anon
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                       cache_key                       
+-------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_anon
+(1 row)
+
+  drop policy "p_anon" on public.documents;
+  -- POSITIVE: to authenticated -> FLAG (still a logic error for a null-sub session)
+  create policy "p_authn" on public.documents for select to authenticated
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                       cache_key                        
+--------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_authn
+(1 row)
+
+  drop policy "p_authn" on public.documents;
+  -- POSITIVE: FOR ALL (USING is the read filter) -> FLAG
+  create policy "p_all" on public.documents for all to authenticated
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key, metadata->>'command' as command
+  from lint."0030_rls_policy_null_auth_disjunct";
+                      cache_key                       | command 
+------------------------------------------------------+---------
+ rls_policy_null_auth_disjunct_public_documents_p_all | ALL
+(1 row)
+
+  drop policy "p_all" on public.documents;
+  -- POSITIVE: NOT (auth.uid() IS NOT NULL) inversion -> FLAG
+  create policy "p_inverted" on public.documents for select to public
+    using (not (auth.uid() is not null) or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                         cache_key                         
+-----------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_inverted
+(1 row)
+
+  drop policy "p_inverted" on public.documents;
+  -- POSITIVE: current_setting(name, true) IS NULL -> FLAG
+  create policy "p_setting_true" on public.documents for select to public
+    using (current_setting('app.tenant', true) is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                           cache_key                           
+---------------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_setting_true
+(1 row)
+
+  drop policy "p_setting_true" on public.documents;
+  -- POSITIVE: null-check as the SECOND disjunct -> FLAG
+  create policy "p_second" on public.documents for select to public
+    using (owner_id = auth.uid() or auth.uid() is null);
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                        cache_key                        
+---------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_second
+(1 row)
+
+  drop policy "p_second" on public.documents;
+  -- POSITIVE: auth.jwt() IS NULL -> FLAG
+  create policy "p_jwt" on public.documents for select to public
+    using (auth.jwt() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                      cache_key                       
+------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_jwt
+(1 row)
+
+  drop policy "p_jwt" on public.documents;
+  -- POSITIVE: auth.role() IS NULL -> FLAG
+  create policy "p_role" on public.documents for select to public
+    using (auth.role() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                       cache_key                       
+-------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_role
+(1 row)
+
+  drop policy "p_role" on public.documents;
+  -- POSITIVE: NULL-check as one of three top-level OR disjuncts -> FLAG
+  create policy "p_three" on public.documents for select to public
+    using (owner_id = auth.uid() or is_public or auth.uid() is null);
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+                       cache_key                        
+--------------------------------------------------------
+ rls_policy_null_auth_disjunct_public_documents_p_three
+(1 row)
+
+  drop policy "p_three" on public.documents;
+  ----------------------------------------------------------------
+  -- NEGATIVE: IS NOT NULL AND ... (the correct form) -> 0 rows
+  ----------------------------------------------------------------
+  create policy "n_and" on public.documents for select to public
+    using (auth.uid() is not null and owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_and" on public.documents;
+  -- NEGATIVE: plain scoped predicate -> 0 rows
+  create policy "n_scoped" on public.documents for select to public
+    using (owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_scoped" on public.documents;
+  -- NEGATIVE: current_user IS NULL (never NULL) -> 0 rows
+  create policy "n_curuser" on public.documents for select to public
+    using (current_user is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_curuser" on public.documents;
+  -- NEGATIVE: top-level OR but neither disjunct is a NULL-auth check -> 0 rows
+  create policy "n_jwt_value" on public.documents for select to public
+    using ((auth.jwt() ->> 'role') = 'admin' or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_jwt_value" on public.documents;
+  -- NEGATIVE: current_setting(name, false) IS NULL (raises, not nullable) -> 0 rows
+  create policy "n_setting_false" on public.documents for select to public
+    using (current_setting('app.tenant', false) is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_setting_false" on public.documents;
+  -- NEGATIVE: NULL-check gated by a top-level AND -> 0 rows
+  create policy "n_nested" on public.documents for select to public
+    using (owner_id = auth.uid() and (auth.uid() is null or is_public));
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_nested" on public.documents;
+  -- NEGATIVE: write command (UPDATE) is out of scope for this read-side lint -> 0 rows
+  create policy "n_update" on public.documents for update to authenticated
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_update" on public.documents;
+  -- NEGATIVE: custom role (not anon/authenticated/public) -> 0 rows
+  create role custom_role_0030;
+  create policy "n_customrole" on public.documents for select to custom_role_0030
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_customrole" on public.documents;
+  drop role custom_role_0030;
+  -- NEGATIVE: restrictive policy -> 0 rows (only permissive policies are flagged)
+  create policy "n_restrictive" on public.documents as restrictive for select to public
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "n_restrictive" on public.documents;
+  -- NEGATIVE: RLS not enabled on the table -> 0 rows
+  create table public.no_rls(id int primary key, owner_id uuid);
+  create policy "n_norls" on public.no_rls for select to public
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop table public.no_rls;
+  ----------------------------------------------------------------
+  -- RESOLUTION: drop the IS NULL disjunct -> 0 rows
+  ----------------------------------------------------------------
+  create policy "fixed" on public.documents for select to public
+    using (owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
+  drop policy "fixed" on public.documents;
+rollback;

--- a/test/expected/queries_are_unionable.out
+++ b/test/expected/queries_are_unionable.out
@@ -54,7 +54,9 @@ begin;
     union all
     select * from lint."0028_anon_security_definer_function_executable"
     union all
-    select * from lint."0029_authenticated_security_definer_function_executable";
+    select * from lint."0029_authenticated_security_definer_function_executable"
+    union all
+    select * from lint."0030_rls_policy_null_auth_disjunct";
  name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
 ------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
 (0 rows)

--- a/test/sql/0030_rls_policy_null_auth_disjunct.sql
+++ b/test/sql/0030_rls_policy_null_auth_disjunct.sql
@@ -1,0 +1,151 @@
+begin;
+  set local search_path = '';
+
+  -- BASELINE: 0 issues on empty schema
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+
+  create table public.documents(
+    id int primary key,
+    owner_id uuid,
+    is_public boolean
+  );
+  alter table public.documents enable row level security;
+
+  ----------------------------------------------------------------
+  -- POSITIVE: auth.uid() IS NULL disjunct, to public -> FLAG
+  ----------------------------------------------------------------
+  create policy "p_public" on public.documents for select to public
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key, metadata->>'roles' as roles, metadata->>'command' as command
+  from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_public" on public.documents;
+
+  -- POSITIVE: to anon -> FLAG
+  create policy "p_anon" on public.documents for select to anon
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_anon" on public.documents;
+
+  -- POSITIVE: to authenticated -> FLAG (still a logic error for a null-sub session)
+  create policy "p_authn" on public.documents for select to authenticated
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_authn" on public.documents;
+
+  -- POSITIVE: FOR ALL (USING is the read filter) -> FLAG
+  create policy "p_all" on public.documents for all to authenticated
+    using (auth.uid() is null or owner_id = auth.uid());
+  select cache_key, metadata->>'command' as command
+  from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_all" on public.documents;
+
+  -- POSITIVE: NOT (auth.uid() IS NOT NULL) inversion -> FLAG
+  create policy "p_inverted" on public.documents for select to public
+    using (not (auth.uid() is not null) or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_inverted" on public.documents;
+
+  -- POSITIVE: current_setting(name, true) IS NULL -> FLAG
+  create policy "p_setting_true" on public.documents for select to public
+    using (current_setting('app.tenant', true) is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_setting_true" on public.documents;
+
+  -- POSITIVE: null-check as the SECOND disjunct -> FLAG
+  create policy "p_second" on public.documents for select to public
+    using (owner_id = auth.uid() or auth.uid() is null);
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_second" on public.documents;
+
+  -- POSITIVE: auth.jwt() IS NULL -> FLAG
+  create policy "p_jwt" on public.documents for select to public
+    using (auth.jwt() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_jwt" on public.documents;
+
+  -- POSITIVE: auth.role() IS NULL -> FLAG
+  create policy "p_role" on public.documents for select to public
+    using (auth.role() is null or owner_id = auth.uid());
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_role" on public.documents;
+
+  -- POSITIVE: NULL-check as one of three top-level OR disjuncts -> FLAG
+  create policy "p_three" on public.documents for select to public
+    using (owner_id = auth.uid() or is_public or auth.uid() is null);
+  select cache_key from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "p_three" on public.documents;
+
+  ----------------------------------------------------------------
+  -- NEGATIVE: IS NOT NULL AND ... (the correct form) -> 0 rows
+  ----------------------------------------------------------------
+  create policy "n_and" on public.documents for select to public
+    using (auth.uid() is not null and owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_and" on public.documents;
+
+  -- NEGATIVE: plain scoped predicate -> 0 rows
+  create policy "n_scoped" on public.documents for select to public
+    using (owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_scoped" on public.documents;
+
+  -- NEGATIVE: current_user IS NULL (never NULL) -> 0 rows
+  create policy "n_curuser" on public.documents for select to public
+    using (current_user is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_curuser" on public.documents;
+
+  -- NEGATIVE: top-level OR but neither disjunct is a NULL-auth check -> 0 rows
+  create policy "n_jwt_value" on public.documents for select to public
+    using ((auth.jwt() ->> 'role') = 'admin' or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_jwt_value" on public.documents;
+
+  -- NEGATIVE: current_setting(name, false) IS NULL (raises, not nullable) -> 0 rows
+  create policy "n_setting_false" on public.documents for select to public
+    using (current_setting('app.tenant', false) is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_setting_false" on public.documents;
+
+  -- NEGATIVE: NULL-check gated by a top-level AND -> 0 rows
+  create policy "n_nested" on public.documents for select to public
+    using (owner_id = auth.uid() and (auth.uid() is null or is_public));
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_nested" on public.documents;
+
+  -- NEGATIVE: write command (UPDATE) is out of scope for this read-side lint -> 0 rows
+  create policy "n_update" on public.documents for update to authenticated
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_update" on public.documents;
+
+  -- NEGATIVE: custom role (not anon/authenticated/public) -> 0 rows
+  create role custom_role_0030;
+  create policy "n_customrole" on public.documents for select to custom_role_0030
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_customrole" on public.documents;
+  drop role custom_role_0030;
+
+  -- NEGATIVE: restrictive policy -> 0 rows (only permissive policies are flagged)
+  create policy "n_restrictive" on public.documents as restrictive for select to public
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "n_restrictive" on public.documents;
+
+  -- NEGATIVE: RLS not enabled on the table -> 0 rows
+  create table public.no_rls(id int primary key, owner_id uuid);
+  create policy "n_norls" on public.no_rls for select to public
+    using (auth.uid() is null or owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop table public.no_rls;
+
+  ----------------------------------------------------------------
+  -- RESOLUTION: drop the IS NULL disjunct -> 0 rows
+  ----------------------------------------------------------------
+  create policy "fixed" on public.documents for select to public
+    using (owner_id = auth.uid());
+  select * from lint."0030_rls_policy_null_auth_disjunct";
+  drop policy "fixed" on public.documents;
+
+rollback;

--- a/test/sql/queries_are_unionable.sql
+++ b/test/sql/queries_are_unionable.sql
@@ -56,6 +56,8 @@ begin;
     union all
     select * from lint."0028_anon_security_definer_function_executable"
     union all
-    select * from lint."0029_authenticated_security_definer_function_executable";
+    select * from lint."0029_authenticated_security_definer_function_executable"
+    union all
+    select * from lint."0030_rls_policy_null_auth_disjunct";
 
 rollback;


### PR DESCRIPTION
Implements the read-side inverted-auth lint proposed in #165 — a permissive `SELECT` / `ALL` policy whose `USING` has a **top-level OR disjunct that is true when a nullable auth function is NULL**:

```sql
using ( auth.uid() is null or owner_id = auth.uid() )
```

For any session where `auth.uid()` is NULL the disjunct short-circuits the `OR`, so the policy admits **every row**. Supported nullable functions: `auth.uid()`, `auth.jwt()`, `auth.role()`, and `current_setting(name, true)`, plus the `NOT (… IS NOT NULL)` inversion.

### Framing

Per #165, this is framed as a **correctness defect** — a predicate that is unconditionally true for the NULL-auth case — rather than an "anonymous access" judgement. That keeps it in advisor territory and distinct from the deliberate-anon-access pushback on #28. It complements `0024_rls_policy_always_true` (literal `USING (true)`, write-commands only) and reuses that lint's role filter (`public` / `anon` / `authenticated`).

### Detection

Pure SQL over `pg_policies`: sentinel the nullable null-checks, neutralize function-call parens, then collapse balanced parens to confirm the `OR` is *top-level*. A null-check gated by a top-level `AND` (e.g. `owner_id = auth.uid() AND (auth.uid() IS NULL OR is_public)`) is **not** flagged. FP-clean on `current_user`, `current_setting(name)` / `(name, false)`, `IS NOT NULL AND …`, nested-in-AND, restrictive policies, custom roles, write commands, and RLS-off tables.

### The two open questions from #165

- **Fresh lint vs. revive #28:** went with a fresh lint (`0030`) — happy to renumber.
- **Severity:** `WARN` — happy to switch to `INFO`.

### Tests

Built with the `/new-lint` workflow. `test/sql/0030_rls_policy_null_auth_disjunct.sql` covers **10 positive + 10 negative** cases (the auth.uid/jwt/role variants, the `NOT (… IS NOT NULL)` inversion, `current_setting(…, true)`, second/third-disjunct placement; negatives for `current_user`, `current_setting(…, false)`, `IS NOT NULL AND`, nested-in-AND, write commands, custom roles, restrictive, and RLS-off). The full pg_regress suite (**all 29 tests**) passes on `supabase/postgres:15.1.1.13`.

Closes the implementation discussion in #165.
