### PR TITLE
fix(0002): constrain pg_depend classid/refclassid to avoid cross-catalog oid collisions

### DIFF
--- a/lints/0002_auth_users_exposed.sql
+++ b/lints/0002_auth_users_exposed.sql
@@ -27,16 +27,18 @@ from
         and auth_users_pg_class.relname = 'users'
         and auth_users_pg_namespace.nspname = 'auth'
     -- Depends on auth.users
+    -- objid/refobjid are only unique within a (class, refclass), so both must
+    -- be constrained or a numerically equal oid from another catalog matches
     join pg_catalog.pg_depend d
         on d.refobjid = auth_users_pg_class.oid
+        and d.refclassid = 'pg_catalog.pg_class'::regclass
+        and d.classid = 'pg_catalog.pg_rewrite'::regclass
     join pg_catalog.pg_rewrite r
         on r.oid = d.objid
     join pg_catalog.pg_class c
         on c.oid = r.ev_class
     join pg_catalog.pg_namespace n
         on n.oid = c.relnamespace
-    join pg_catalog.pg_class pg_class_auth_users
-        on d.refobjid = pg_class_auth_users.oid
 where
     d.deptype = 'n'
     and (
@@ -80,7 +82,7 @@ where
                     'security_invoker=on'
                 ]
             )
-            and not pg_class_auth_users.relrowsecurity
+            and not auth_users_pg_class.relrowsecurity
         )
     )
 group by

--- a/splinter.sql
+++ b/splinter.sql
@@ -127,16 +127,18 @@ from
         and auth_users_pg_class.relname = 'users'
         and auth_users_pg_namespace.nspname = 'auth'
     -- Depends on auth.users
+    -- objid/refobjid are only unique within a (class, refclass), so both must
+    -- be constrained or a numerically equal oid from another catalog matches
     join pg_catalog.pg_depend d
         on d.refobjid = auth_users_pg_class.oid
+        and d.refclassid = 'pg_catalog.pg_class'::regclass
+        and d.classid = 'pg_catalog.pg_rewrite'::regclass
     join pg_catalog.pg_rewrite r
         on r.oid = d.objid
     join pg_catalog.pg_class c
         on c.oid = r.ev_class
     join pg_catalog.pg_namespace n
         on n.oid = c.relnamespace
-    join pg_catalog.pg_class pg_class_auth_users
-        on d.refobjid = pg_class_auth_users.oid
 where
     d.deptype = 'n'
     and (
@@ -180,7 +182,7 @@ where
                     'security_invoker=on'
                 ]
             )
-            and not pg_class_auth_users.relrowsecurity
+            and not auth_users_pg_class.relrowsecurity
         )
     )
 group by

--- a/test/expected/0002_auth_users_exposed.out
+++ b/test/expected/0002_auth_users_exposed.out
@@ -46,4 +46,30 @@ begin;
 ------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
 (0 rows)
 
+    rollback to savepoint a;
+    -- Not a failure mode: a view depending on an object from another catalog
+    -- whose oid numerically collides with auth.users' pg_class oid.
+    -- pg_depend.refobjid is only unique within a refclassid, so without a
+    -- refclassid filter such a view is reported even though it never
+    -- references auth.users.
+    create table public.orders (id int primary key);
+    create function public.order_count() returns bigint language sql as
+        $$select pg_catalog.count(*) from public.orders$$;
+    -- move the function's pg_proc oid onto auth.users' pg_class oid
+    update pg_catalog.pg_proc
+        set oid = (
+            select c.oid
+            from pg_catalog.pg_class c
+            join pg_catalog.pg_namespace n
+                on n.oid = c.relnamespace
+            where n.nspname = 'auth' and c.relname = 'users'
+        )
+        where oid = 'public.order_count'::pg_catalog.regproc;
+    create view public.order_stats as select public.order_count() as total;
+    -- 0 entries
+    select * from lint."0002_auth_users_exposed";
+ name | title | level | facing | categories | description | detail | remediation | metadata | cache_key 
+------+-------+-------+--------+------------+-------------+--------+-------------+----------+-----------
+(0 rows)
+
 rollback;

--- a/test/sql/0002_auth_users_exposed.sql
+++ b/test/sql/0002_auth_users_exposed.sql
@@ -37,4 +37,30 @@ begin;
     select * from lint."0002_auth_users_exposed";
 
 
+    rollback to savepoint a;
+
+
+    -- Not a failure mode: a view depending on an object from another catalog
+    -- whose oid numerically collides with auth.users' pg_class oid.
+    -- pg_depend.refobjid is only unique within a refclassid, so without a
+    -- refclassid filter such a view is reported even though it never
+    -- references auth.users.
+    create table public.orders (id int primary key);
+    create function public.order_count() returns bigint language sql as
+        $$select pg_catalog.count(*) from public.orders$$;
+    -- move the function's pg_proc oid onto auth.users' pg_class oid
+    update pg_catalog.pg_proc
+        set oid = (
+            select c.oid
+            from pg_catalog.pg_class c
+            join pg_catalog.pg_namespace n
+                on n.oid = c.relnamespace
+            where n.nspname = 'auth' and c.relname = 'users'
+        )
+        where oid = 'public.order_count'::pg_catalog.regproc;
+    create view public.order_stats as select public.order_count() as total;
+    -- 0 entries
+    select * from lint."0002_auth_users_exposed";
+
+
 rollback;


### PR DESCRIPTION
Fixes #171.

### Problem

`0002_auth_users_exposed` joins `pg_depend` to `auth.users` on `refobjid` alone:

```sql
join pg_catalog.pg_depend d
    on d.refobjid = auth_users_pg_class.oid
```

`pg_depend.objid` / `refobjid` are only unique within a `(classid, refclassid)` pair. Without those predicates, a dependency row that points at an object in a *different* catalog whose oid happens to equal `auth.users`' `pg_class` oid is matched too.

In the reported case a public view called a SECURITY DEFINER helper function whose `pg_proc` oid equalled `auth.users`' `pg_class` oid (16499). The view selects only from public tables and has no relation dependency on `auth.users`, yet it was reported as CRITICAL `auth_users_exposed` and triggered an "action required: security vulnerabilities" email.

### Fix

Constrain both sides of the join:

```sql
join pg_catalog.pg_depend d
    on d.refobjid = auth_users_pg_class.oid
    and d.refclassid = 'pg_catalog.pg_class'::regclass
    and d.classid = 'pg_catalog.pg_rewrite'::regclass
```

This matches the filters the other lints already carry after #166 ("objid is only unique within a classid"), which added `classid` predicates to 0001, 0004-0011, 0016 and 0017 but did not touch this join in 0002.

Also drops the redundant `join pg_catalog.pg_class pg_class_auth_users on d.refobjid = pg_class_auth_users.oid`. Once `refclassid` is constrained it always resolves to the same row as `auth_users_pg_class`, which is already restricted to `auth.users`, so `relrowsecurity` is read from that alias instead.

No change to the lint's true positives: a view or materialized view whose rewrite really depends on `auth.users` still carries `classid = pg_rewrite` and `refclassid = pg_class`.

### Test

An oid collision cannot be produced by waiting for one, so the regression case forces it inside the test transaction: a function is created, its `pg_proc` oid is moved onto `auth.users`' `pg_class` oid, and a view that calls the function (and never references `auth.users`) is created. The lint must return 0 rows. On `main` that view is reported; with this change it is not. Everything runs inside the existing `begin` / `rollback`.

`splinter.sql` regenerated via `bin/compile.py`.

### Verification

- `docker compose -f dockerfiles/docker-compose.yml run --rm test` on `supabase/postgres:15.1.1.13` — all 28 tests pass.
- `pre-commit run --all-files` — all hooks pass.