### PR TITLE
docs: add CLAUDE.md documenting the local pre-push gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,10 @@ Guidance for Claude Code sessions working in this repo.
 ## What this is
 
 `splinter` (Supabase Postgres LINTER) maintains a set of SQL-based lints for
-Supabase Postgres projects, checked via `bin/check_lints.py` and compiled
-via `bin/compile.py`.
+Supabase Postgres projects. `bin/check_lints.py` checks every lint is fully
+registered, and `bin/compile.py` compiles all lint views into the tracked,
+generated `splinter.sql` (`UNION ALL` of every `lints/*.sql` view) - don't
+hand-edit `splinter.sql` directly, it's overwritten by `bin/compile.py`.
 
 ## Build / test / lint
 
@@ -15,22 +17,23 @@ pre-commit run --all-files
 ```
 
 Runs the full local gate, matching `.github/workflows/pre-commit_hooks.yaml`:
-`black` (pinned to `24.2.0` in `.pre-commit-config.yaml` - install that exact
-version in a venv, since a newer `black`'s reformatting can differ),
-`bin/compile.py` (compiles the SQL lint files), `bin/check_lints.py` (checks
-every lint is fully registered), plus standard hygiene hooks
-(trailing-whitespace, check-yaml, mixed-line-ending, remove-tabs).
+`black` (pinned to `24.2.0` in `.pre-commit-config.yaml`, needs a `python3.12`
+interpreter on PATH for its hook env - pre-commit installs `black` itself, no
+manual install needed), `bin/compile.py` (regenerates `splinter.sql`),
+`bin/check_lints.py` (checks every lint is fully registered), plus standard
+hygiene hooks (trailing-whitespace, excluding `test/expected` since those
+`.out` files are whitespace-exact pg_regress golden files; check-added-large-files;
+check-yaml; mixed-line-ending; remove-tabs).
 
 ```
-PG_VERSION=<version> docker compose -f dockerfiles/docker-compose.yml build
-PG_VERSION=<version> docker compose -f dockerfiles/docker-compose.yml run test
+docker rmi -f dockerfiles-test
+SUPABASE_VERSION=15.1.1.13 docker-compose -f dockerfiles/docker-compose.yml run --rm test
 ```
 
 Runs the real pg_regress test suite against a live Postgres, matching
-`.github/workflows/test.yml`. Rebuild with `--no-cache` after any
-dependency/lockfile change - a bare `docker compose run` reuses the last
-built image and can report a stale pass.
-
-A CI failure right after a commit that looks unrelated to your own change
-can be drift on `main` picked up by a merge, not a regression in your own
-work - diff `origin/main` fresh before assuming it's self-inflicted.
+`.github/workflows/test.yml`'s effective behavior (which sets `PG_VERSION`,
+not `SUPABASE_VERSION` - a repo-side no-op both there and here, since
+`dockerfiles/docker-compose.yml` only reads `SUPABASE_VERSION` for its build
+arg). The `docker rmi -f` first is required, not optional: `docker compose
+run` reuses the last built image, so a lint/test/expected-file change without
+it can report a stale pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+Guidance for Claude Code sessions working in this repo.
+
+## What this is
+
+`splinter` (Supabase Postgres LINTER) maintains a set of SQL-based lints for
+Supabase Postgres projects, checked via `bin/check_lints.py` and compiled
+via `bin/compile.py`.
+
+## Build / test / lint
+
+```
+pre-commit run --all-files
+```
+
+Runs the full local gate, matching `.github/workflows/pre-commit_hooks.yaml`:
+`black` (pinned to `24.2.0` in `.pre-commit-config.yaml` - install that exact
+version in a venv, since a newer `black`'s reformatting can differ),
+`bin/compile.py` (compiles the SQL lint files), `bin/check_lints.py` (checks
+every lint is fully registered), plus standard hygiene hooks
+(trailing-whitespace, check-yaml, mixed-line-ending, remove-tabs).
+
+```
+PG_VERSION=<version> docker compose -f dockerfiles/docker-compose.yml build
+PG_VERSION=<version> docker compose -f dockerfiles/docker-compose.yml run test
+```
+
+Runs the real pg_regress test suite against a live Postgres, matching
+`.github/workflows/test.yml`. Rebuild with `--no-cache` after any
+dependency/lockfile change - a bare `docker compose run` reuses the last
+built image and can report a stale pass.
+
+A CI failure right after a commit that looks unrelated to your own change
+can be drift on `main` picked up by a merge, not a regression in your own
+work - diff `origin/main` fresh before assuming it's self-inflicted.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` documenting what this repo is and its local pre-push gate: `pre-commit run --all-files` and the docker-compose pg_regress suite. Every command in the file was run for real against this repo, not just read from the workflow YAML.

(bot-generated information collapsed below)

---

<details><summary>Details</summary>

- `splinter` had no `CLAUDE.md` at all before this PR.
- A correctness and a spec-fidelity review pass each independently found the same real bug in the first draft: `PG_VERSION` never selects a Postgres version, since `dockerfiles/docker-compose.yml` only reads `SUPABASE_VERSION` for its build arg (confirmed via `docker compose config` with both variables set). The file now documents the working form, matching this repo's own README and `.claude/skills/new-lint/SKILL.md`.
- Also corrected: the staleness advice named a trigger condition (a dependency/lockfile change) that can't occur in this repo, and omitted the real one (any lint/test/expected-file change); the black-version bullet told the reader to install black in a venv when `pre-commit` already manages that itself; the hygiene-hook list was missing `check-added-large-files`.
- Both documented commands were re-run for real after the fixes: `pre-commit run --all-files` (8/8 hooks passed) and the docker-compose pg_regress suite (28/28 tests passed).

</details>

---

Resolves https://linear.app/supabase/issue/INDATA-1481

<!-- pr-checkpoint sha=b1081bef51a2c9e7bea213d796da3b7b4c17e4c0 ts=2026-09-03T16:38:40Z -->
