### PR TITLE
fix: minor improvements to the lint manifest build

### DIFF
--- a/bin/compile_json.py
+++ b/bin/compile_json.py
@@ -32,9 +32,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import compile  # noqa: E402  (bin/compile.py; import after sys.path setup)
 
 NAME_RE = re.compile(r"'([a-z0-9_]+)'\s+as\s+name", re.IGNORECASE)
-CATEGORIES_RE = re.compile(
-    r"array\[(.*?)\]\s+as\s+categories", re.IGNORECASE | re.DOTALL
-)
+CATEGORIES_RE = re.compile(r"array\[([^\]]*)\]\s+as\s+categories", re.IGNORECASE)
+
+VALID_CATEGORIES = {"SECURITY", "PERFORMANCE"}
 
 
 def extract_name(stem: str, query: str) -> str:
@@ -56,6 +56,9 @@ def extract_categories(stem: str, query: str) -> List[str]:
     ]
     if not categories:
         raise SystemExit(f"lint {stem!r}: empty categories array")
+    invalid = [c for c in categories if c not in VALID_CATEGORIES]
+    if invalid:
+        raise SystemExit(f"lint {stem!r}: invalid categories {invalid}")
     return categories
 
 


### PR DESCRIPTION
`bin/compile_json.py` pulls each lint's `categories` out of its SQL with a greedy `array\[(.*?)\] ... as categories` regex under `re.DOTALL`. In a lint that contains an earlier `array[...]` (a data array, not the categories projection), the lazy capture spans across it to the trailing `as categories` and returns the whole run as "categories".

Three lints are affected because they have a data array above the projection: `0023_sensitive_columns_exposed`, `0024_rls_policy_always_true`, `0025_public_bucket_allows_listing`. Instead of `['SECURITY']` they emit dozens of SQL fragments. Since consumers filter by category (mgmt-api does `lint.categories.includes(category)`), a Security Advisor run requested by category through the Management API or MCP silently omits those three. Running all lints, as Studio does, is unaffected. This is in the 2026.08.0 and 2026.09.0 manifests.

This matches a single `array[...]` with `[^\]]*` (and drops `DOTALL`), so the capture can't leave its own array, and validates every extracted category against the known set so a malformed lint fails the build loudly rather than shipping bad metadata — the behaviour the module docstring already describes.

Verified by running `bin/compile_json.py` over all 29 lints: every lint now resolves to `SECURITY`/`PERFORMANCE`, and 0023/0024/0025 come out as `['SECURITY']`.

Tracking: PSQL-1655
